### PR TITLE
chore: update stale bot to not close issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,29 +2,27 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '15 7 * * *'
+    - cron: "15 7 * * *"
 
 jobs:
   stale:
-
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v3
-      with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-issue-stale: 60
-        days-before-pr-stale: 30
-        days-before-issue-close: 365
-        days-before-pr-close: -1
-        stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'
-        stale-issue-label: 'lifecycle/stale'
-        stale-pr-message: 'This PR is stale because it has been open 30 days with no activity.'
-        stale-pr-label: 'lifecycle/stale'
-        close-issue-message: 'This issue was closed because it has been stalled for 365 days with no activity.'
-        close-issue-label: 'lifecycle/rotten'
-        exempt-issue-labels: 'lifecycle/frozen'
-        exempt-pr-labels: 'lifecycle/frozen'
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 180
+          days-before-pr-stale: 60
+          days-before-issue-close: -1
+          days-before-pr-close: -1
+          stale-issue-message: "This issue is stale because it has been open 180 days with no activity."
+          stale-issue-label: "lifecycle/stale"
+          stale-pr-message: "This PR is stale because it has been open 60 days with no activity."
+          stale-pr-label: "lifecycle/stale"
+          close-issue-label: "lifecycle/rotten"
+          exempt-issue-labels: "lifecycle/frozen"
+          exempt-pr-labels: "lifecycle/frozen"


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the GHA stale workflow to not close issues. Also increases the time frame to when a issue or PR is marked as stale.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #864 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
