### PR TITLE
fix: cloud hypervisor auto starts

### DIFF
--- a/core/errors/errors.go
+++ b/core/errors/errors.go
@@ -136,7 +136,7 @@ type notSupportedError struct {
 
 // Error returns the error message.
 func (e notSupportedError) Error() string {
-	return e.unsupported + "is not supported"
+	return e.unsupported + " is not supported"
 }
 
 // IsNotSupported tests an error to see if its a not supported error.

--- a/infrastructure/microvm/cloudhypervisor/provider.go
+++ b/infrastructure/microvm/cloudhypervisor/provider.go
@@ -56,7 +56,7 @@ type provider struct {
 
 // Capabilities returns a list of the capabilities the provider supports.
 func (p *provider) Capabilities() models.Capabilities {
-	return []models.Capability{}
+	return []models.Capability{models.AutoStartCapability}
 }
 
 // Start will start a created microvm.


### PR DESCRIPTION
**What this PR does / why we need it**:

The Cloud Hypervisor provider wasn't marked with the auto start capability and so when a new VM was created the **Start** method was called on the provider which resulted in a error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #919 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes

