### PR TITLE
fix release version for github action (issue: 556 action-gh-release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         name: flintlock-binaries
         path: bin
     - name: Release
-      uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+      uses: softprops/action-gh-release@51cfd90a6d81cfe329568f851fe2236ab4416d17 # v2.2.0
       with:
         prerelease: false
         draft: true


### PR DESCRIPTION
Github release had a bad release version that was referenced.

https://github.com/softprops/action-gh-release/issues/556