### PR TITLE
fixing connection leak

### DIFF
--- a/pkg/cloudhypervisor/client.go
+++ b/pkg/cloudhypervisor/client.go
@@ -109,6 +109,7 @@ func New(socketPath string) Client {
 		DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
 			return net.Dial("unix", socketPath)
 		},
+		DisableKeepAlives: true, // Disable keep-alive to ensure connections are closed after use
 	}
 
 	return &client{


### PR DESCRIPTION
Connections are bing held open

```
time="2025-02-07T22:43:08Z" level=error msg="failed to reconcile vmid default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6: executing plan: executing plan steps: creating plan for microvm_create_update: adding microvm create step: checking if step microvm_create should be included in plan: checking if microvm is running: querying cloud-hypervisor for info: ErrValidator: response error for http://localhost/api/v1/vm.info: unexpected status: 503" controller=microvm
```

You can see it when you query the cloud-hypervisor endpoint

```
curl --unix-socket /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock -i      -X GET 'http://localhost/api/v1/vm.info'      -H 'Accept: application/json'
HTTP/1.1 503
Server: Firecracker API
Connection: close
Content-Length: 40

{ "error": "Too many open connections" }
```

```
ss -x src /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock
Netid State Recv-Q  Send-Q                                                                                         Local Address:Port        Peer Address:Port                                                                          Process                                                                     
u_str ESTAB 0       0        /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock 466487811              * 466500160                                                                                                                                                 
u_str ESTAB 0       0        /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock 467253079              * 467255974                                                                                                                                                 
u_str ESTAB 0       0        /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock 467686370              * 467714155                                                                                                                                                 
u_str ESTAB 0       0        /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock 467106000              * 467102932                                                                                                                                                 
u_str ESTAB 0       0        /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock 466518211              * 466523167                                                                                                                                                 
u_str ESTAB 0       0        /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock 466898784              * 466891312                                                                                                                                                 
u_str ESTAB 0       0        /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock 467538803              * 467548650                                                                                                                                                 
u_str ESTAB 0       0        /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock 466559899              * 466599155                                                                                                                                                 
u_str ESTAB 0       0        /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock 466518212              * 466477831                                                                                                                                                 
u_str ESTAB 0       0        /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock 467384219              * 467407150  

ss -x src /var/lib/flintlock/vm/default/home-cluster-ch-msfvf/01JKH54Z3YSC0KFSKZW8NM5TP6/cloudhypervisor.sock | grep ESTAB | wc -l
10
```
