### PR TITLE
wip: sqlite for vm spec storage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -114,6 +114,7 @@ require (
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-sqlite3 v1.14.24 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/sys/mountinfo v0.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -592,6 +592,8 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-shellwords v1.0.12/go.mod h1:EZzvwXDESEeg03EKmM+RmDnNOPKG4lLtQsUlTZDWQ8Y=
+github.com/mattn/go-sqlite3 v1.14.24 h1:tpSp2G2KyMnnQu99ngJ47EIkWVmliIizyZBfPrBWDRM=
+github.com/mattn/go-sqlite3 v1.14.24/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mdlayher/socket v0.2.0/go.mod h1:QLlNPkFR88mRUNQIzRBMfXxwKal8H7u1h3bL1CV+f0E=

--- a/infrastructure/sqlite/migration.go
+++ b/infrastructure/sqlite/migration.go
@@ -1,0 +1,66 @@
+package sqlite
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+type migration struct {
+	version int
+	up      string
+}
+
+func createMigrationsTable(db *sql.DB) error {
+	_, err := db.Exec(`
+		CREATE TABLE IF NOT EXISTS schema_migrations (
+			version INTEGER PRIMARY KEY,
+			applied_at DATETIME DEFAULT CURRENT_TIMESTAMP
+		)
+	`)
+	return err
+}
+
+func runMigrations(db *sql.DB, migrations []migration) error {
+	// Get the current schema version
+	var currentVersion int
+	err := db.QueryRow(`
+		SELECT COALESCE(MAX(version), 0) 
+		FROM schema_migrations
+	`).Scan(&currentVersion)
+	if err != nil {
+		return fmt.Errorf("getting current schema version: %w", err)
+	}
+
+	// Run each migration in a transaction
+	for _, m := range migrations {
+		if m.version <= currentVersion {
+			continue
+		}
+
+		tx, err := db.Begin()
+		if err != nil {
+			return fmt.Errorf("beginning transaction for migration %d: %w", m.version, err)
+		}
+
+		// Run the migration
+		if _, err := tx.Exec(m.up); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("running migration %d: %w", m.version, err)
+		}
+
+		// Record the migration
+		if _, err := tx.Exec(`
+			INSERT INTO schema_migrations (version) 
+			VALUES (?)
+		`, m.version); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("recording migration %d: %w", m.version, err)
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("committing migration %d: %w", m.version, err)
+		}
+	}
+
+	return nil
+}

--- a/infrastructure/sqlite/repository.go
+++ b/infrastructure/sqlite/repository.go
@@ -1,0 +1,294 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/liquidmetal-dev/flintlock/core/errors"
+	"github.com/liquidmetal-dev/flintlock/core/models"
+	"github.com/liquidmetal-dev/flintlock/core/ports"
+	"github.com/liquidmetal-dev/flintlock/pkg/log"
+)
+
+type Config struct {
+	DatabasePath string
+}
+
+type sqliteRepo struct {
+	db     *sql.DB
+	locks  map[string]*sync.RWMutex
+	lockMu sync.Mutex
+}
+
+// NewMicroVMRepo creates a new SQLite-backed microvm repository.
+func NewMicroVMRepo(cfg *Config) (ports.MicroVMRepository, error) {
+	dataPath := filepath.Dir(cfg.DatabasePath)
+	if _, err := os.Stat(dataPath); os.IsNotExist(err) {
+		if err := os.MkdirAll(dataPath, 0o755); err != nil {
+			return nil, fmt.Errorf("creating data directory: %w", err)
+		}
+	}
+
+	db, err := sql.Open("sqlite3", cfg.DatabasePath)
+	if err != nil {
+		return nil, fmt.Errorf("opening sqlite database: %w", err)
+	}
+
+	// Create tables if they don't exist
+	if err := initDatabase(db); err != nil {
+		return nil, fmt.Errorf("initializing database: %w", err)
+	}
+
+	return &sqliteRepo{
+		db:    db,
+		locks: make(map[string]*sync.RWMutex),
+	}, nil
+}
+
+func initDatabase(db *sql.DB) error {
+	// Create migrations table first
+	if err := createMigrationsTable(db); err != nil {
+		return fmt.Errorf("creating migrations table: %w", err)
+	}
+
+	// Run migrations
+	migrations := []migration{
+		{
+			version: 1,
+			up: `
+				CREATE TABLE IF NOT EXISTS microvms (
+					uid TEXT NOT NULL,
+					name TEXT NOT NULL,
+					namespace TEXT NOT NULL,
+					version INTEGER NOT NULL,
+					spec TEXT NOT NULL,
+					created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+					PRIMARY KEY (uid, version)
+				)
+			`,
+		},
+		// Add new migrations here with version numbers 2, 3, etc.
+	}
+
+	return runMigrations(db, migrations)
+}
+
+func (r *sqliteRepo) Save(ctx context.Context, microvm *models.MicroVM) (*models.MicroVM, error) {
+	logger := log.GetLogger(ctx).WithField("repo", "sqlite_microvm")
+	logger.Debugf("saving microvm spec %s", microvm.ID)
+
+	mu := r.getMutex(microvm.ID.String())
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Check if exists and compare
+	existing, err := r.get(ctx, ports.RepositoryGetOptions{
+		Name:      microvm.ID.Name(),
+		Namespace: microvm.ID.Namespace(),
+		UID:       microvm.ID.UID(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("checking existing vm: %w", err)
+	}
+
+	if existing != nil {
+		// If exactly the same, return existing
+		specBytes, err := json.Marshal(microvm)
+		if err != nil {
+			return nil, fmt.Errorf("marshalling new spec: %w", err)
+		}
+
+		existingBytes, err := json.Marshal(existing)
+		if err != nil {
+			return nil, fmt.Errorf("marshalling existing spec: %w", err)
+		}
+
+		if string(specBytes) == string(existingBytes) {
+			return existing, nil
+		}
+	}
+
+	// Increment version
+	microvm.Version++
+
+	// Marshal the entire microvm to JSON
+	specJSON, err := json.Marshal(microvm)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling microvm: %w", err)
+	}
+
+	// Insert new version
+	_, err = r.db.ExecContext(ctx, `
+		INSERT INTO microvms (uid, name, namespace, version, spec)
+		VALUES (?, ?, ?, ?, ?)
+	`, microvm.ID.UID(), microvm.ID.Name(), microvm.ID.Namespace(), microvm.Version, string(specJSON))
+	if err != nil {
+		return nil, fmt.Errorf("inserting microvm: %w", err)
+	}
+
+	return microvm, nil
+}
+
+func (r *sqliteRepo) Get(ctx context.Context, options ports.RepositoryGetOptions) (*models.MicroVM, error) {
+	mu := r.getMutex(options.Name)
+	mu.RLock()
+	defer mu.RUnlock()
+
+	vm, err := r.get(ctx, options)
+	if err != nil {
+		return nil, fmt.Errorf("getting vm from db: %w", err)
+	}
+
+	if vm == nil {
+		return nil, errors.NewSpecNotFound(
+			options.Name,
+			options.Namespace,
+			options.Version,
+			options.UID)
+	}
+
+	return vm, nil
+}
+
+func (r *sqliteRepo) get(ctx context.Context, options ports.RepositoryGetOptions) (*models.MicroVM, error) {
+	query := `
+		SELECT spec FROM microvms 
+		WHERE name = ? AND namespace = ?
+	`
+	args := []interface{}{options.Name, options.Namespace}
+
+	if options.UID != "" {
+		query += " AND uid = ?"
+		args = append(args, options.UID)
+	}
+
+	if options.Version != "" {
+		query += " AND version = ?"
+		args = append(args, options.Version)
+	} else {
+		query += " ORDER BY version DESC LIMIT 1"
+	}
+
+	var specJSON string
+	err := r.db.QueryRowContext(ctx, query, args...).Scan(&specJSON)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying database: %w", err)
+	}
+
+	var microvm models.MicroVM
+	if err := json.Unmarshal([]byte(specJSON), &microvm); err != nil {
+		return nil, fmt.Errorf("unmarshalling spec: %w", err)
+	}
+
+	return &microvm, nil
+}
+
+func (r *sqliteRepo) GetAll(ctx context.Context, query models.ListMicroVMQuery) ([]*models.MicroVM, error) {
+	sqlQuery := `
+		SELECT m1.spec 
+		FROM microvms m1
+		INNER JOIN (
+			SELECT uid, MAX(version) as max_version 
+			FROM microvms 
+			GROUP BY uid
+		) m2 
+		ON m1.uid = m2.uid AND m1.version = m2.max_version
+		WHERE 1=1
+	`
+	var args []interface{}
+
+	if query["namespace"] != "" {
+		sqlQuery += " AND namespace = ?"
+		args = append(args, query["namespace"])
+	}
+	if query["name"] != "" {
+		sqlQuery += " AND name = ?"
+		args = append(args, query["name"])
+	}
+
+	rows, err := r.db.QueryContext(ctx, sqlQuery, args...)
+	if err != nil {
+		return nil, fmt.Errorf("querying database: %w", err)
+	}
+	defer rows.Close()
+
+	var results []*models.MicroVM
+	for rows.Next() {
+		var specJSON string
+		if err := rows.Scan(&specJSON); err != nil {
+			return nil, fmt.Errorf("scanning row: %w", err)
+		}
+
+		var microvm models.MicroVM
+		if err := json.Unmarshal([]byte(specJSON), &microvm); err != nil {
+			return nil, fmt.Errorf("unmarshalling spec: %w", err)
+		}
+
+		results = append(results, &microvm)
+	}
+
+	return results, nil
+}
+
+func (r *sqliteRepo) Delete(ctx context.Context, microvm *models.MicroVM) error {
+	mu := r.getMutex(microvm.ID.String())
+	mu.Lock()
+	defer mu.Unlock()
+
+	_, err := r.db.ExecContext(ctx, `
+		DELETE FROM microvms 
+		WHERE uid = ? AND namespace = ? AND name = ?
+	`, microvm.ID.UID(), microvm.ID.Namespace(), microvm.ID.Name())
+	if err != nil {
+		return fmt.Errorf("deleting from database: %w", err)
+	}
+
+	return nil
+}
+
+func (r *sqliteRepo) Exists(ctx context.Context, vmid models.VMID) (bool, error) {
+	mu := r.getMutex(vmid.String())
+	mu.RLock()
+	defer mu.RUnlock()
+
+	var exists bool
+	err := r.db.QueryRowContext(ctx, `
+		SELECT EXISTS(
+			SELECT 1 FROM microvms 
+			WHERE uid = ? AND namespace = ? AND name = ?
+		)
+	`, vmid.UID(), vmid.Namespace(), vmid.Name()).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("checking existence: %w", err)
+	}
+
+	return exists, nil
+}
+
+func (r *sqliteRepo) ReleaseLease(ctx context.Context, microvm *models.MicroVM) error {
+	// No-op for SQLite as we don't use leases
+	return nil
+}
+
+func (r *sqliteRepo) getMutex(name string) *sync.RWMutex {
+	r.lockMu.Lock()
+	defer r.lockMu.Unlock()
+
+	mu, ok := r.locks[name]
+	if !ok {
+		mu = &sync.RWMutex{}
+		r.locks[name] = mu
+	}
+
+	return mu
+}

--- a/internal/command/flags/flags.go
+++ b/internal/command/flags/flags.go
@@ -33,6 +33,7 @@ const (
 	cloudHypervisorBinFlag    = "cloudhypervisor-bin"
 	cloudHypervisorDetachFlag = "cloudhypervisor-detach"
 	virtioFSBinFlag           = "virtiofs-bin"
+	dataPathFlag              = "data-path"
 )
 
 // AddGRPCServerFlagsToCommand will add gRPC server flags to the supplied command.
@@ -46,6 +47,11 @@ func AddGRPCServerFlagsToCommand(cmd *cobra.Command, cfg *config.Config) {
 		"state-dir",
 		defaults.StateRootDir,
 		"The directory to use for the as the root for runtime state.")
+
+	cmd.Flags().StringVar(&cfg.DataPath,
+		"data-dir",
+		fmt.Sprintf("%s/data", defaults.StateRootDir),
+		"The directory to use for general data storage.")
 
 	cmd.Flags().DurationVar(&cfg.ResyncPeriod,
 		"resync-period",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,8 @@ type Config struct {
 	DebugEndpoint string
 	// DefaultVMProvider specifies the name of the microvm provider to use by default.
 	DefaultVMProvider string
+	// DataPath is the path to the data directory.
+	DataPath string
 }
 
 // TLSConfig holds the configuration for TLS.

--- a/internal/inject/wire.go
+++ b/internal/inject/wire.go
@@ -4,6 +4,7 @@
 package inject
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/google/wire"
@@ -17,6 +18,7 @@ import (
 	microvmgrpc "github.com/liquidmetal-dev/flintlock/infrastructure/grpc"
 	"github.com/liquidmetal-dev/flintlock/infrastructure/microvm"
 	"github.com/liquidmetal-dev/flintlock/infrastructure/network"
+	"github.com/liquidmetal-dev/flintlock/infrastructure/sqlite"
 	"github.com/liquidmetal-dev/flintlock/infrastructure/ulid"
 	"github.com/liquidmetal-dev/flintlock/infrastructure/virtiofs"
 	"github.com/liquidmetal-dev/flintlock/internal/config"
@@ -26,13 +28,15 @@ import (
 func InitializePorts(cfg *config.Config) (*ports.Collection, error) {
 	wire.Build(containerd.NewEventService,
 		containerd.NewImageService,
-		containerd.NewMicroVMRepo,
+		// containerd.NewMicroVMRepo,
+		sqlite.NewMicroVMRepo,
 		ulid.New,
 		microvm.NewFromConfig,
 		network.New,
 		godisk.New,
 		appPorts,
 		containerdConfig,
+		sqliteConfig,
 		networkConfig,
 		afero.NewOsFs,
 		virtiofs.New)
@@ -64,6 +68,12 @@ func containerdConfig(cfg *config.Config) *containerd.Config {
 		SnapshotterVolume: defaults.ContainerdVolumeSnapshotter,
 		SocketPath:        cfg.CtrSocketPath,
 		Namespace:         cfg.CtrNamespace,
+	}
+}
+
+func sqliteConfig(cfg *config.Config) *sqlite.Config {
+	return &sqlite.Config{
+		DatabasePath: fmt.Sprintf("%s/microvm.db", cfg.DataPath),
 	}
 }
 

--- a/internal/inject/wire_gen.go
+++ b/internal/inject/wire_gen.go
@@ -15,6 +15,7 @@ import (
 	"github.com/liquidmetal-dev/flintlock/infrastructure/grpc"
 	"github.com/liquidmetal-dev/flintlock/infrastructure/microvm"
 	"github.com/liquidmetal-dev/flintlock/infrastructure/network"
+	"github.com/liquidmetal-dev/flintlock/infrastructure/sqlite"
 	"github.com/liquidmetal-dev/flintlock/infrastructure/ulid"
 	"github.com/liquidmetal-dev/flintlock/infrastructure/virtiofs"
 	"github.com/liquidmetal-dev/flintlock/internal/config"
@@ -26,8 +27,8 @@ import (
 // Injectors from wire.go:
 
 func InitializePorts(cfg *config.Config) (*ports.Collection, error) {
-	config2 := containerdConfig(cfg)
-	microVMRepository, err := containerd.NewMicroVMRepo(config2)
+	config2 := sqliteConfig(cfg)
+	microVMRepository, err := sqlite.NewMicroVMRepo(config2)
 	if err != nil {
 		return nil, err
 	}
@@ -39,12 +40,13 @@ func InitializePorts(cfg *config.Config) (*ports.Collection, error) {
 	if err != nil {
 		return nil, err
 	}
-	eventService, err := containerd.NewEventService(config2)
+	config4 := containerdConfig(cfg)
+	eventService, err := containerd.NewEventService(config4)
 	if err != nil {
 		return nil, err
 	}
 	idService := ulid.New()
-	imageService, err := containerd.NewImageService(config2)
+	imageService, err := containerd.NewImageService(config4)
 	if err != nil {
 		return nil, err
 	}
@@ -82,6 +84,12 @@ func containerdConfig(cfg *config.Config) *containerd.Config {
 		SnapshotterVolume: defaults.ContainerdVolumeSnapshotter,
 		SocketPath:        cfg.CtrSocketPath,
 		Namespace:         cfg.CtrNamespace,
+	}
+}
+
+func sqliteConfig(cfg *config.Config) *sqlite.Config {
+	return &sqlite.Config{
+		DatabasePath: cfg.DataPath,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Change flintlock to use sqlite for storing the microvmn specs instead of containerd. This will help with querying etc,

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
