### PR TITLE
fix(grpc): validate the payload for Kernel info

### DIFF
--- a/infrastructure/grpc/convert.go
+++ b/infrastructure/grpc/convert.go
@@ -17,6 +17,11 @@ func convertMicroVMToModel(spec *types.MicroVMSpec) (*models.MicroVM, error) {
 		uid = *spec.Uid
 	}
 
+	if spec.Kernel == nil {
+		// Add the kernel to the spec if it's missing so that we can correctly progress to the validate step
+		spec.Kernel = &types.Kernel{}
+	}
+
 	vmid, err := models.NewVMID(spec.Id, spec.Namespace, uid)
 	if err != nil {
 		return nil, fmt.Errorf("creating vmid from spec: %w", err)


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

I was having some difficulty debugging a custom implementation of interacting with the liquidmetal service over GRPC from a golang client. It was quite difficult and annoying to debug as my requests were segfaulting the remote liquidmetal service.

Turns out it was just strugglign to parse information from the grpc request that i was constructing which was not fully formed.

This adds the missing data required for this to progress to the validation step which then has nice feedback for what parts are missing:

```
creating microvm: an error occurred when attempting to validate microvm spec: validation failures found: Key: 'MicroVM.Spec.Kernel.Filename' Error:Field validation for 'Filename' failed on the 'required' tag Key: 'MicroVM.Spec.root_volume' Error:Field validation for 'root_volume' failed on the 'volumeOrInitrdRequired' tag
```


To recreate: 

```
	vmReq := &flintlock.CreateMicroVMRequest{
		Microvm: &types.MicroVMSpec{
			Id:        id,
			Namespace: namespace,
			Interfaces: []*types.NetworkInterface{
				{
					Type:     types.NetworkInterface_TAP,
					DeviceId: "tap0",
				},
			},
		},
	}
	res, err := s.client.CreateMicroVM(context.Background(), vmReq)

```

This causes it to segfault

```
vmReq := &flintlock.CreateMicroVMRequest{
		Microvm: &types.MicroVMSpec{
			Id:        id,
			Namespace: namespace,
			Kernel: &types.Kernel{
				Image: "ghcr.io/weaveworks-liquidmetal/kernel-bin:5.10.77",
			},
			Interfaces: []*types.NetworkInterface{
				{
					Type:     types.NetworkInterface_TAP,
					DeviceId: "tap0",
				},
			},
		},
	}
	res, err := s.client.CreateMicroVM(context.Background(), vmReq)

```

This progresses to the validation step.


With the changes to this pr the error of the original broken request rather than sefaulting isntead becomes:

```
 creating microvm: an error occurred when attempting to validate microvm spec: validation failures found: Key: 'MicroVM.Spec.root_volume' Error:Field validation for 'root_volume' failed on the 'volumeOrInitrdRequired' tag 
```


**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [x] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
