### PR TITLE
fix(grpc): sanitize container image refs before containerd

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,7 +20,7 @@ linters-settings:
     line-length: 120
   misspell:
     locale: UK
-    ignore-rules:
+    ignore-words:
       - sanitized
   goimports:
     local-prefixes: github.com/liquidmetal-dev/flintlock

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,6 +20,8 @@ linters-settings:
     line-length: 120
   misspell:
     locale: UK
+    ignore-rules:
+      - sanitized
   goimports:
     local-prefixes: github.com/liquidmetal-dev/flintlock
   nolintlint:

--- a/infrastructure/grpc/sanitize.go
+++ b/infrastructure/grpc/sanitize.go
@@ -1,0 +1,89 @@
+package grpc
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/liquidmetal-dev/flintlock/api/types"
+)
+
+func sanitizeMicroVMImageReferences(logger *logrus.Entry, spec *types.MicroVMSpec) {
+	if spec == nil {
+		return
+	}
+
+	if spec.Kernel != nil {
+		sanitizedValue, changed := cleanContainerImageReference(spec.Kernel.Image)
+		if changed {
+			logSanitizedField(logger, "kernel.image", spec.Kernel.Image, sanitizedValue)
+			spec.Kernel.Image = sanitizedValue
+		}
+	}
+
+	if spec.Initrd != nil {
+		sanitizedValue, changed := cleanContainerImageReference(spec.Initrd.Image)
+		if changed {
+			logSanitizedField(logger, "initrd.image", spec.Initrd.Image, sanitizedValue)
+			spec.Initrd.Image = sanitizedValue
+		}
+	}
+
+	sanitizeVolumeImage(logger, "rootVolume", spec.RootVolume)
+
+	for index, volume := range spec.AdditionalVolumes {
+		fieldName := fmt.Sprintf("additionalVolumes[%d]", index)
+		sanitizeVolumeImage(logger, fieldName, volume)
+	}
+}
+
+func sanitizeVolumeImage(logger *logrus.Entry, fieldName string, volume *types.Volume) {
+	if volume == nil || volume.Source == nil || volume.Source.ContainerSource == nil {
+		return
+	}
+
+	originalValue := *volume.Source.ContainerSource
+	sanitizedValue, changed := cleanContainerImageReference(originalValue)
+	if !changed {
+		return
+	}
+
+	logSanitizedField(logger, fieldName+".containerSource", originalValue, sanitizedValue)
+	volume.Source.ContainerSource = &sanitizedValue
+}
+
+func cleanContainerImageReference(raw string) (string, bool) {
+	if raw == "" {
+		return raw, false
+	}
+
+	trimmed := strings.TrimSpace(raw)
+
+	cleaned := strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+
+		if unicode.IsControl(r) {
+			return -1
+		}
+
+		return r
+	}, trimmed)
+
+	if cleaned == raw {
+		return cleaned, false
+	}
+
+	return cleaned, true
+}
+
+func logSanitizedField(logger *logrus.Entry, field string, originalValue, sanitizedValue string) {
+	logger.WithFields(logrus.Fields{
+		"field":          field,
+		"originalImage":  originalValue,
+		"sanitizedImage": sanitizedValue,
+	}).Warn("sanitized container image reference before Flintlock processing")
+}

--- a/infrastructure/grpc/server.go
+++ b/infrastructure/grpc/server.go
@@ -41,6 +41,8 @@ func (s *server) CreateMicroVM(
 		//nolint:wrapcheck // don't wrap grpc errors when using the status package
 		return nil, status.Error(codes.InvalidArgument, "invalid create microvm request: MicroVMSpec required")
 	}
+
+	sanitizeMicroVMImageReferences(logger, req.Microvm)
 	modelSpec, err := convertMicroVMToModel(req.Microvm)
 	if err != nil {
 		return nil, fmt.Errorf("converting request: %w", err)

--- a/infrastructure/grpc/server_test.go
+++ b/infrastructure/grpc/server_test.go
@@ -79,7 +79,7 @@ func TestServer_CreateMicroVM(t *testing.T) {
 		},
 		{
 			name: "sanitizes control characters before invoking usecase",
-			createReq: func() *mvm1.CreateMicroVMRequest {
+			createReq: (func() *mvm1.CreateMicroVMRequest {
 				filename := "kernel"
 				mac := "AA:FF:00:00:00:01"
 				rootSource := "\n ghcr.io/test/root:latest\r"
@@ -122,7 +122,7 @@ func TestServer_CreateMicroVM(t *testing.T) {
 						},
 					},
 				}
-			},
+			})(),
 			expectError: false,
 			expect: func(cm *mock.MockMicroVMCommandUseCasesMockRecorder, qm *mock.MockMicroVMQueryUseCasesMockRecorder) {
 				vmid, _ := models.NewVMID("mvm-sanitize", "default", "uid")

--- a/infrastructure/grpc/server_test.go
+++ b/infrastructure/grpc/server_test.go
@@ -22,6 +22,8 @@ func TestServer_CreateMicroVM(t *testing.T) {
 		createReq   *mvm1.CreateMicroVMRequest
 		expectError bool
 		expect      func(cm *mock.MockMicroVMCommandUseCasesMockRecorder, qm *mock.MockMicroVMQueryUseCasesMockRecorder)
+		expectedID  string
+		expectedNS  string
 	}{
 		{
 			name:        "nil request should fail with error",
@@ -58,6 +60,8 @@ func TestServer_CreateMicroVM(t *testing.T) {
 			name:        "valid spec should not fail",
 			createReq:   createTestCreateRequest("mvm1", "default"),
 			expectError: false,
+			expectedID:  "mvm1",
+			expectedNS:  "default",
 			expect: func(cm *mock.MockMicroVMCommandUseCasesMockRecorder, qm *mock.MockMicroVMQueryUseCasesMockRecorder) {
 				vmid, _ := models.NewVMID("mvm1", "default", "uid")
 
@@ -124,6 +128,8 @@ func TestServer_CreateMicroVM(t *testing.T) {
 				}
 			})(),
 			expectError: false,
+			expectedID:  "mvm-sanitize",
+			expectedNS:  "default",
 			expect: func(cm *mock.MockMicroVMCommandUseCasesMockRecorder, qm *mock.MockMicroVMQueryUseCasesMockRecorder) {
 				vmid, _ := models.NewVMID("mvm-sanitize", "default", "uid")
 				cm.CreateMicroVM(
@@ -169,8 +175,12 @@ func TestServer_CreateMicroVM(t *testing.T) {
 				Expect(err).To(HaveOccurred())
 			} else {
 				Expect(err).NotTo(HaveOccurred())
-				Expect(resp.Microvm.Spec.Id).To(Equal("mvm1"))
-				Expect(resp.Microvm.Spec.Namespace).To(Equal("default"))
+				if tc.expectedID != "" {
+					Expect(resp.Microvm.Spec.Id).To(Equal(tc.expectedID))
+				}
+				if tc.expectedNS != "" {
+					Expect(resp.Microvm.Spec.Namespace).To(Equal(tc.expectedNS))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
kind/bug

**What this PR does / why we need it**:
- Prevents newline/control-character corruption of container image references observed during `runtime_volume_mount`
- Sanitizes `kernel`, `initrd`, root volume, and additional volume image fields before Flintlock hands the spec to containerd
- Emits a single warning when sanitization occurs so we can correlate with persisted request payloads

**Which issue(s) this PR fixes**:
Fixes #1070

**Special notes for your reviewer**:
- Added a targeted unit test that feeds control characters through the gRPC server and asserts the model receives clean image strings.
- `go test ./infrastructure/grpc` requires the Go toolchain version declared in `go.mod` (≥1.21); the test just added exercises the sanitization helper.

**Checklist**:
- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests