### PR TITLE
feat: Add hosted runner e2e workflow

### DIFF
--- a/.github/workflows/hosted_e2e.yml
+++ b/.github/workflows/hosted_e2e.yml
@@ -1,7 +1,12 @@
 name: hosted e2e
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      firecracker_version:
+        description: "Firecracker release tag to install"
+        required: false
+        default: "v1.15.1"
   schedule:
     - cron: "0 2 * * *"
 
@@ -38,17 +43,17 @@ jobs:
             wget
 
       - name: Install Firecracker
-        run: sudo ./hack/scripts/provision.sh firecracker
+        env:
+          FIRECRACKER: ${{ github.event.inputs.firecracker_version || 'v1.15.1' }}
+        run: sudo -E ./hack/scripts/provision.sh firecracker
 
-      - name: Prepare KVM access
+      - name: Verify KVM access
         run: |
           if [[ ! -c /dev/kvm ]]; then
             echo "/dev/kvm not found. GitHub-hosted e2e tests require KVM." >&2
             exit 1
           fi
 
-          ls -l /dev/kvm
-          sudo chmod 0666 /dev/kvm
           ls -l /dev/kvm
 
           if command -v lscpu >/dev/null 2>&1; then
@@ -59,9 +64,8 @@ jobs:
         run: |
           sudo env \
             "PATH=$PATH" \
-            "HOME=$HOME" \
-            "GOCACHE=$GOCACHE" \
-            "GOMODCACHE=$GOMODCACHE" \
+            "GOCACHE=/tmp/go-cache" \
+            "GOMODCACHE=/tmp/go-mod" \
             make test-e2e
 
       - name: Cleanup e2e resources

--- a/.github/workflows/hosted_e2e.yml
+++ b/.github/workflows/hosted_e2e.yml
@@ -1,0 +1,83 @@
+name: hosted e2e
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0 2 * * *"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: hosted-e2e-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    name: e2e tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: "${{ github.workspace }}/go.mod"
+          check-latest: true
+          cache: false
+
+      - name: Install host dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            bc \
+            containerd \
+            curl \
+            lvm2 \
+            thin-provisioning-tools \
+            wget
+
+      - name: Install Firecracker
+        run: sudo ./hack/scripts/provision.sh firecracker
+
+      - name: Prepare KVM access
+        run: |
+          if [[ ! -c /dev/kvm ]]; then
+            echo "/dev/kvm not found. GitHub-hosted e2e tests require KVM." >&2
+            exit 1
+          fi
+
+          ls -l /dev/kvm
+          sudo chmod 0666 /dev/kvm
+          ls -l /dev/kvm
+
+          if command -v lscpu >/dev/null 2>&1; then
+            lscpu | grep -E "Virtualization|Hypervisor|Vendor ID|Model name" || true
+          fi
+
+      - name: Run e2e tests
+        run: |
+          sudo env \
+            "PATH=$PATH" \
+            "HOME=$HOME" \
+            "GOCACHE=$GOCACHE" \
+            "GOMODCACHE=$GOMODCACHE" \
+            make test-e2e
+
+      - name: Cleanup e2e resources
+        if: always()
+        run: |
+          sudo dmsetup remove --force dev-thinpool-e2e || true
+
+          while IFS=: read -r device _; do
+            if [[ -n "$device" ]]; then
+              sudo losetup -d "$device" || true
+            fi
+          done < <(losetup -a | grep -E "/var/lib/containerd-dev/snapshotter/devmapper/(data|metadata)-e2e" || true)
+
+          sudo rm -rf \
+            /run/containerd-e2e \
+            /var/lib/containerd-e2e \
+            /var/lib/containerd-dev/snapshotter/devmapper/data-e2e \
+            /var/lib/containerd-dev/snapshotter/devmapper/metadata-e2e \
+            /var/lib/flintlock

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -42,6 +42,18 @@ This exact command will run tests against main of the upstream branch, and only 
 minimal configuration. Read the tool [usage docs](/test/tools/README.md) for information
 on how to configure and use the tool in your development.
 
+### In GitHub Actions on hosted runners
+
+The `hosted e2e` workflow runs the e2e suite directly on `ubuntu-latest` GitHub
+hosted runners. It is available via `workflow_dispatch` and also runs nightly.
+
+The workflow prepares the runner by installing the host packages required by the
+test harness, installing Firecracker, checking that `/dev/kvm` exists, and
+relaxing `/dev/kvm` permissions for the duration of the job. The tests are run
+with `sudo` because they create loop devices and devicemapper thinpools, write
+containerd configuration under `/etc`, and manage runtime state under `/run` and
+`/var/lib`.
+
 ### Configuration
 
 There are a couple of custom test flags which you can set to alter the behaviour

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -48,11 +48,10 @@ The `hosted e2e` workflow runs the e2e suite directly on `ubuntu-latest` GitHub
 hosted runners. It is available via `workflow_dispatch` and also runs nightly.
 
 The workflow prepares the runner by installing the host packages required by the
-test harness, installing Firecracker, checking that `/dev/kvm` exists, and
-relaxing `/dev/kvm` permissions for the duration of the job. The tests are run
-with `sudo` because they create loop devices and devicemapper thinpools, write
-containerd configuration under `/etc`, and manage runtime state under `/run` and
-`/var/lib`.
+test harness, installing Firecracker, and checking that `/dev/kvm` exists. The
+tests are run with `sudo` because they create loop devices and devicemapper
+thinpools, write containerd configuration under `/etc`, and manage runtime state
+under `/run` and `/var/lib`.
 
 ### Configuration
 


### PR DESCRIPTION
## Summary
- add a manual and nightly GitHub-hosted runner e2e workflow
- prepare KVM access on ubuntu-latest before running the existing e2e suite
- document how hosted-runner e2e works and why it runs with sudo

## Validation
- parsed .github/workflows/hosted_e2e.yml as YAML
- ran GOCACHE=/tmp/go-build GOMODCACHE=/tmp/go-mod make compile-e2e

## Notes
- full hosted e2e execution needs to run in GitHub Actions because it requires KVM and root-level runner setup