### PR TITLE
fix(cloudhypervisor): stop create race spawning duplicate VMM

### DIFF
--- a/infrastructure/microvm/cloudhypervisor/create.go
+++ b/infrastructure/microvm/cloudhypervisor/create.go
@@ -33,13 +33,26 @@ func (p *provider) Create(ctx context.Context, vm *models.MicroVM) error {
 	// should already prevent this, but this is a belt-and-suspenders check against a
 	// double-spawn (Address in use) or orphaning a running process by deleting its
 	// socket in ensureState.
-	if pidExists, _ := afero.Exists(p.fs, vmState.PIDPath()); pidExists {
-		if pid, perr := vmState.PID(); perr == nil {
-			if live, _ := process.Exists(pid); live {
-				logger.Debug("cloud-hypervisor already running for this microvm, skipping create")
+	pidExists, err := afero.Exists(p.fs, vmState.PIDPath())
+	if err != nil {
+		return fmt.Errorf("checking pid file exists: %w", err)
+	}
 
-				return nil
-			}
+	if pidExists {
+		pid, err := vmState.PID()
+		if err != nil {
+			return fmt.Errorf("getting pid from file: %w", err)
+		}
+
+		live, err := process.Exists(pid)
+		if err != nil {
+			return fmt.Errorf("checking if cloudhypervisor process is running: %w", err)
+		}
+
+		if live {
+			logger.Debug("cloud-hypervisor already running for this microvm, skipping create")
+
+			return nil
 		}
 	}
 

--- a/infrastructure/microvm/cloudhypervisor/create.go
+++ b/infrastructure/microvm/cloudhypervisor/create.go
@@ -28,6 +28,21 @@ func (p *provider) Create(ctx context.Context, vm *models.MicroVM) error {
 	})
 	logger.Debugf("creating microvm")
 	vmState := NewState(vm.ID, p.config.StateRoot, p.fs)
+
+	// Never re-create over a live cloud-hypervisor. The State()-based create guard
+	// should already prevent this, but this is a belt-and-suspenders check against a
+	// double-spawn (Address in use) or orphaning a running process by deleting its
+	// socket in ensureState.
+	if pidExists, _ := afero.Exists(p.fs, vmState.PIDPath()); pidExists {
+		if pid, perr := vmState.PID(); perr == nil {
+			if live, _ := process.Exists(pid); live {
+				logger.Debug("cloud-hypervisor already running for this microvm, skipping create")
+
+				return nil
+			}
+		}
+	}
+
 	if err := p.ensureState(vmState); err != nil {
 		return fmt.Errorf("ensuring state dir: %w", err)
 	}
@@ -83,7 +98,7 @@ func (p *provider) startCloudHypervisor(_ context.Context,
 	}
 
 	if startErr != nil {
-		return nil, fmt.Errorf("starting cloud hypervisor process: %w", err)
+		return nil, fmt.Errorf("starting cloud hypervisor process: %w", startErr)
 	}
 
 	return cmd.Process, nil
@@ -202,7 +217,7 @@ func (p *provider) ensureState(vmState State) error {
 
 	if sockExists {
 		if delErr := p.fs.Remove(vmState.SockPath()); delErr != nil {
-			return fmt.Errorf("deleting existing sock file: %w", err)
+			return fmt.Errorf("deleting existing sock file: %w", delErr)
 		}
 	}
 

--- a/infrastructure/microvm/cloudhypervisor/create_test.go
+++ b/infrastructure/microvm/cloudhypervisor/create_test.go
@@ -1,0 +1,37 @@
+package cloudhypervisor
+
+import (
+	"context"
+	"testing"
+
+	g "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+
+	"github.com/liquidmetal-dev/flintlock/core/models"
+)
+
+// TestCreateSkipsWhenProcessAlive verifies the belt-and-suspenders guard in
+// Create(): if a live cloud-hypervisor already owns this microvm, Create() is a
+// no-op and must not touch (delete) the existing socket, which would orphan the
+// running process.
+func TestCreateSkipsWhenProcessAlive(t *testing.T) {
+	g.RegisterTestingT(t)
+
+	p, id, vmState := newTestProvider(t)
+
+	// A live process owns the vm...
+	g.Expect(vmState.SetPid(startLiveProcess(t))).To(g.Succeed())
+	// ...and an existing socket file that must survive.
+	g.Expect(afero.WriteFile(p.fs, vmState.SockPath(), []byte{}, 0o600)).To(g.Succeed())
+
+	vmid, err := models.NewVMIDFromString(id)
+	g.Expect(err).NotTo(g.HaveOccurred())
+
+	err = p.Create(context.Background(), &models.MicroVM{ID: *vmid})
+	g.Expect(err).NotTo(g.HaveOccurred())
+
+	// Guard fired: socket left intact (ensureState never ran to remove it).
+	sockExists, err := afero.Exists(p.fs, vmState.SockPath())
+	g.Expect(err).NotTo(g.HaveOccurred())
+	g.Expect(sockExists).To(g.BeTrue())
+}

--- a/infrastructure/microvm/cloudhypervisor/provider.go
+++ b/infrastructure/microvm/cloudhypervisor/provider.go
@@ -104,28 +104,36 @@ func (p *provider) State(ctx context.Context, id string) (ports.MicroVMState, er
 		return ports.MicroVMStatePending, nil
 	}
 
+	// The pid file exists and the process is alive, so this microvm is ours. From
+	// here we never report Pending: doing so would let the create step's ShouldDo
+	// re-fire Create() and spawn a second cloud-hypervisor on the same API socket
+	// (Address in use) while the first, healthy process is still coming up. This
+	// mirrors the firecracker provider, which treats "pid alive" as Running.
 	sockExists, err := afero.Exists(p.fs, vmState.SockPath())
 	if err != nil {
 		return ports.MicroVMStateUnknown, fmt.Errorf("checking sock file exists: %w", err)
 	}
 
 	if !sockExists {
-		return ports.MicroVMStatePending, nil
+		// Process is up but has not bound its API socket yet (still booting).
+		return ports.MicroVMStateRunning, nil
 	}
 
 	chClient := cloudhypervisor.New(vmState.SockPath())
 
 	vmInfo, err := chClient.Info(ctx)
 	if err != nil {
-		return ports.MicroVMStateUnknown, fmt.Errorf("querying cloud-hypervisor for info: %w", err)
+		// Transient error while the process is coming up (e.g. socket not yet
+		// serving). Trust process liveness rather than re-firing the create.
+		logger.WithError(err).Warn("querying cloud-hypervisor for info, assuming running as process is alive")
+
+		return ports.MicroVMStateRunning, nil
 	}
 
 	// NOTE: we can support paused/unpause in the future
 	switch vmInfo.State {
-	case cloudhypervisor.VMStateRunning:
+	case cloudhypervisor.VMStateRunning, cloudhypervisor.VMStateCreated:
 		return ports.MicroVMStateRunning, nil
-	case cloudhypervisor.VMStateCreated:
-		return ports.MicroVMStatePending, nil
 	default:
 		return ports.MicroVMStateUnknown, fmt.Errorf("cloud-hypervisor in an unsupported state: %s", vmInfo.State)
 	}

--- a/infrastructure/microvm/cloudhypervisor/provider_test.go
+++ b/infrastructure/microvm/cloudhypervisor/provider_test.go
@@ -1,0 +1,184 @@
+package cloudhypervisor
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"testing"
+
+	g "github.com/onsi/gomega"
+	"github.com/spf13/afero"
+
+	"github.com/liquidmetal-dev/flintlock/core/models"
+	"github.com/liquidmetal-dev/flintlock/core/ports"
+	"github.com/liquidmetal-dev/flintlock/pkg/cloudhypervisor"
+)
+
+const (
+	testVMName      = "test"
+	testVMNamespace = "ns"
+	testVMUID       = "344780b0-6249-11ec-90d6-0242ac120003"
+)
+
+// newTestProvider returns a provider backed by a real (OS) filesystem rooted at a
+// temp dir, along with the vmid string and the initialised vm state.
+func newTestProvider(t *testing.T) (*provider, string, State) {
+	t.Helper()
+
+	fs := afero.NewOsFs()
+
+	// Use a short root: the unix socket path derived from it must stay under the
+	// ~108 char sun_path limit, which t.TempDir() (long test names) would blow.
+	stateRoot, err := os.MkdirTemp("", "ch")
+	g.Expect(err).NotTo(g.HaveOccurred())
+	t.Cleanup(func() { _ = os.RemoveAll(stateRoot) })
+
+	p := &provider{
+		config: &Config{StateRoot: stateRoot},
+		fs:     fs,
+	}
+
+	vmid, err := models.NewVMID(testVMName, testVMNamespace, testVMUID)
+	g.Expect(err).NotTo(g.HaveOccurred())
+
+	vmState := NewState(*vmid, stateRoot, fs)
+	g.Expect(fs.MkdirAll(vmState.Root(), 0o755)).To(g.Succeed())
+
+	return p, vmid.String(), vmState
+}
+
+// startLiveProcess spawns a long-lived process and returns its pid. The process is
+// killed on test cleanup.
+func startLiveProcess(t *testing.T) int {
+	t.Helper()
+
+	cmd := exec.Command("sleep", "60")
+	g.Expect(cmd.Start()).To(g.Succeed())
+
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	return cmd.Process.Pid
+}
+
+// deadPID spawns then reaps a process, returning a pid that is no longer alive.
+func deadPID(t *testing.T) int {
+	t.Helper()
+
+	cmd := exec.Command("sleep", "60")
+	g.Expect(cmd.Start()).To(g.Succeed())
+	g.Expect(cmd.Process.Kill()).To(g.Succeed())
+	_, _ = cmd.Process.Wait()
+
+	return cmd.Process.Pid
+}
+
+// serveFakeCH stands up a cloud-hypervisor-like API server on the state's socket
+// path. If chState is empty the /vm.info endpoint returns 500 to simulate a
+// transient error while the process is still coming up.
+func serveFakeCH(t *testing.T, sockPath string, chState cloudhypervisor.VMState) {
+	t.Helper()
+
+	listener, err := net.Listen("unix", sockPath)
+	g.Expect(err).NotTo(g.HaveOccurred())
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/vm.info", func(w http.ResponseWriter, _ *http.Request) {
+		if chState == "" {
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"state":%q}`, chState)
+	})
+
+	srv := &http.Server{Handler: mux} //nolint:gosec // test server
+	go func() { _ = srv.Serve(listener) }()
+
+	t.Cleanup(func() { _ = srv.Close() })
+}
+
+func TestProviderState(t *testing.T) {
+	g.RegisterTestingT(t)
+	ctx := context.Background()
+
+	t.Run("pid file absent returns pending", func(t *testing.T) {
+		g.RegisterTestingT(t)
+		p, id, _ := newTestProvider(t)
+
+		state, err := p.State(ctx, id)
+		g.Expect(err).NotTo(g.HaveOccurred())
+		g.Expect(state).To(g.Equal(ports.MicroVMStatePending))
+	})
+
+	t.Run("process not alive returns pending", func(t *testing.T) {
+		g.RegisterTestingT(t)
+		p, id, vmState := newTestProvider(t)
+		g.Expect(vmState.SetPid(deadPID(t))).To(g.Succeed())
+
+		state, err := p.State(ctx, id)
+		g.Expect(err).NotTo(g.HaveOccurred())
+		g.Expect(state).To(g.Equal(ports.MicroVMStatePending))
+	})
+
+	t.Run("process alive but socket not yet bound returns running", func(t *testing.T) {
+		g.RegisterTestingT(t)
+		p, id, vmState := newTestProvider(t)
+		g.Expect(vmState.SetPid(startLiveProcess(t))).To(g.Succeed())
+
+		state, err := p.State(ctx, id)
+		g.Expect(err).NotTo(g.HaveOccurred())
+		g.Expect(state).To(g.Equal(ports.MicroVMStateRunning))
+	})
+
+	t.Run("process alive and info errors returns running", func(t *testing.T) {
+		g.RegisterTestingT(t)
+		p, id, vmState := newTestProvider(t)
+		g.Expect(vmState.SetPid(startLiveProcess(t))).To(g.Succeed())
+		serveFakeCH(t, vmState.SockPath(), "")
+
+		state, err := p.State(ctx, id)
+		g.Expect(err).NotTo(g.HaveOccurred())
+		g.Expect(state).To(g.Equal(ports.MicroVMStateRunning))
+	})
+
+	t.Run("info created returns running", func(t *testing.T) {
+		g.RegisterTestingT(t)
+		p, id, vmState := newTestProvider(t)
+		g.Expect(vmState.SetPid(startLiveProcess(t))).To(g.Succeed())
+		serveFakeCH(t, vmState.SockPath(), cloudhypervisor.VMStateCreated)
+
+		state, err := p.State(ctx, id)
+		g.Expect(err).NotTo(g.HaveOccurred())
+		g.Expect(state).To(g.Equal(ports.MicroVMStateRunning))
+	})
+
+	t.Run("info running returns running", func(t *testing.T) {
+		g.RegisterTestingT(t)
+		p, id, vmState := newTestProvider(t)
+		g.Expect(vmState.SetPid(startLiveProcess(t))).To(g.Succeed())
+		serveFakeCH(t, vmState.SockPath(), cloudhypervisor.VMStateRunning)
+
+		state, err := p.State(ctx, id)
+		g.Expect(err).NotTo(g.HaveOccurred())
+		g.Expect(state).To(g.Equal(ports.MicroVMStateRunning))
+	})
+
+	t.Run("info shutdown returns unknown with error", func(t *testing.T) {
+		g.RegisterTestingT(t)
+		p, id, vmState := newTestProvider(t)
+		g.Expect(vmState.SetPid(startLiveProcess(t))).To(g.Succeed())
+		serveFakeCH(t, vmState.SockPath(), cloudhypervisor.VMStateShutdown)
+
+		state, err := p.State(ctx, id)
+		g.Expect(err).To(g.HaveOccurred())
+		g.Expect(state).To(g.Equal(ports.MicroVMStateUnknown))
+	})
+}


### PR DESCRIPTION
Fixes #999

## Problem

With `provider: cloudhypervisor`, VM creates intermittently (~1 in 3, worse under nested virt/load) never reach `CREATED`; `cloudhypervisor.stderr` fills with `API socket "…/cloudhypervisor.sock" is already in use by another running instance`. The winning guest boots and networks fine — it's a control-plane reconcile bug, not guest/boot.

Root cause (traced in [#999 (comment)](https://github.com/liquidmetal-dev/flintlock/issues/999#issuecomment-5011653737)):

- `startCloudHypervisor` does `cmd.Start()` and returns before CH binds its API socket or finishes boot.
- The reconcile loop re-invokes the create step's `ShouldDo()` (gated on `State() == Pending`) right after `Do()`.
- CH `State()` returned `Pending` during **two** windows while the process was already alive: pre-socket-bind (`!sockExists`), and boot (`Info() == "Created"`, long under nested virt).
- Either window → the gate re-fires `Create()` → a **second** cloud-hypervisor on the same `--api-socket` (`Address in use` / tap `Resource busy`), and `ensureState()` unlinked the socket out from under the first healthy process → permanent orphan → retries exhaust `MaximumRetry` → `FailedState`.

Firecracker is immune because its `State()` treats "pidfile present + process alive" as `Running`.

## Fix

The double-spawn requires `State()` to return *exactly* `(Pending, nil)`. So: **once our pidfile process is alive, `State()` never returns `Pending`** (mirrors firecracker), keeping `Info()` for richer reporting:

| situation (process alive) | result |
|---|---|
| socket not yet bound | `Running` |
| `Info()` transport error | `Running` (trust liveness, log warn) |
| `Info` = `Running` / `Created` | `Running` |
| `Info` = `Shutdown` / other | `Unknown` + err (post-boot only, safe — `Unknown` ≠ `Pending`) |

This closes both race windows.

Belt-and-suspenders: `Create()` early-returns when the pidfile PID is a live process, so a stray re-create can neither double-spawn nor orphan the socket. Also fixes two pre-existing wrong-error-variable typos (`startErr`, `delErr`).

## Tests

New `provider_test.go` — 7 `State()` cases (real short-lived process for liveness, fake CH HTTP-over-unix server for `Info` states) covering both race windows and the `Info` mapping. New `create_test.go` — the `Create()` guard leaves a live VM's socket intact.

`go build ./...`, `go vet`, and `go test ./core/... ./infrastructure/...` (159 passed) all green. End-to-end repro under nested KVM still needs a real host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)