### PR TITLE
Publish deb/rpm packages with GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,10 @@ jobs:
   #     with:
   #       metal_auth_token: ${{ secrets.METAL_AUTH_TOKEN }}
   #       project_names: ${{ env.PROJECT_NAME }}
-  build:
+  release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Checkout
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -36,38 +38,10 @@ jobs:
         go-version-file: '${{ github.workspace }}/go.mod'
         check-latest: true
         cache: false
-    - name: Build binaries
-      run: make build-release
-    - name: Store flintlock binaries
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
       with:
-        name: flintlock-binaries
-        path: bin/*
-        retention-days: 1
-  release:
-    runs-on: ubuntu-latest
-    needs: [build]
-    permissions:
-      contents: write
-    steps:
-    - name: Checkout
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        fetch-depth: 0
-    - name: Download flintlock binaries
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-      with:
-        name: flintlock-binaries
-        path: bin
-    - name: Release
-      uses: softprops/action-gh-release@132dbbba49e22bd4837f09b46d32a8edaf6baa58 # v2.2.0
-      with:
-        prerelease: false
-        draft: true
-        fail_on_unmatched_files: true
-        generate_release_notes: true
-        files: |
-          bin/flintlockd_amd64
-          bin/flintlockd_arm64
-          bin/flintlock-metrics_amd64
-          bin/flintlock-metrics_arm64
+        distribution: goreleaser
+        args: release --clean
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ out/
 # Bin
 bin/
 
+# goreleaser output
+dist/
+
 # direnv files:
 .envrc
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,97 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: flintlockd
+    main: ./cmd/flintlockd
+    binary: flintlockd
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -X github.com/liquidmetal-dev/flintlock/internal/version.Version={{ .Version }}
+      - -X github.com/liquidmetal-dev/flintlock/internal/version.BuildDate={{ .Date }}
+      - -X github.com/liquidmetal-dev/flintlock/internal/version.CommitHash={{ .ShortCommit }}
+  - id: flintlock-metrics
+    main: ./cmd/flintlock-metrics
+    binary: flintlock-metrics
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -X github.com/liquidmetal-dev/flintlock/internal/version.Version={{ .Version }}
+      - -X github.com/liquidmetal-dev/flintlock/internal/version.BuildDate={{ .Date }}
+      - -X github.com/liquidmetal-dev/flintlock/internal/version.CommitHash={{ .ShortCommit }}
+
+archives:
+  - id: flintlockd
+    ids:
+      - flintlockd
+    formats:
+      - binary
+    name_template: "flintlockd_{{ .Os }}_{{ .Arch }}"
+  - id: flintlock-metrics
+    ids:
+      - flintlock-metrics
+    formats:
+      - binary
+    name_template: "flintlock-metrics_{{ .Os }}_{{ .Arch }}"
+
+nfpms:
+  - id: flintlockd
+    ids:
+      - flintlockd
+    package_name: flintlockd
+    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    bindir: /usr/local/bin
+    vendor: Liquid Metal Authors
+    homepage: https://www.liquidmetal.dev
+    maintainer: Liquid Metal Authors <flintlock@liquidmetal.dev>
+    description: |-
+      Flintlock is a service for creating and managing microVMs, primarily
+      designed to run as part of the Liquid Metal stack.
+    license: Apache 2.0
+    formats:
+      - deb
+      - rpm
+    contents:
+      - src: flintlockd.service
+        dst: /lib/systemd/system/flintlockd.service
+    scripts:
+      postinstall: hack/packaging/flintlockd-postinstall.sh
+  - id: flintlock-metrics
+    ids:
+      - flintlock-metrics
+    package_name: flintlock-metrics
+    file_name_template: "{{ .PackageName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    bindir: /usr/local/bin
+    vendor: Liquid Metal Authors
+    homepage: https://www.liquidmetal.dev
+    maintainer: Liquid Metal Authors <flintlock@liquidmetal.dev>
+    description: |-
+      flintlock-metrics exports microVM metrics collected by flintlock.
+    license: Apache 2.0
+    formats:
+      - deb
+      - rpm
+
+checksum:
+  name_template: "checksums.txt"
+
+release:
+  draft: true
+  prerelease: false
+
+changelog:
+  use: github-native

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,13 +40,13 @@ archives:
       - flintlockd
     formats:
       - binary
-    name_template: "flintlockd_{{ .Os }}_{{ .Arch }}"
+    name_template: "flintlockd_{{ .Arch }}"
   - id: flintlock-metrics
     ids:
       - flintlock-metrics
     formats:
       - binary
-    name_template: "flintlock-metrics_{{ .Os }}_{{ .Arch }}"
+    name_template: "flintlock-metrics_{{ .Arch }}"
 
 nfpms:
   - id: flintlockd

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,6 +68,10 @@ nfpms:
     contents:
       - src: flintlockd.service
         dst: /lib/systemd/system/flintlockd.service
+        packager: deb
+      - src: flintlockd.service
+        dst: /usr/lib/systemd/system/flintlockd.service
+        packager: rpm
     scripts:
       postinstall: hack/packaging/flintlockd-postinstall.sh
   - id: flintlock-metrics

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,10 @@ build-release-flintlock-metrics: $(BIN_DIR) ## Build flintlock-metrics release b
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -v -o $(BIN_DIR)/flintlock-metrics_amd64 -ldflags "-X $(VERSION_PKG).Version=$(VERSION) -X $(VERSION_PKG).BuildDate=$(BUILD_DATE) -X $(VERSION_PKG).CommitHash=$(GIT_COMMIT)" ./$(FLINTLOCK_METRICS_CMD)
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o $(BIN_DIR)/flintlock-metrics_arm64 -ldflags "-X $(VERSION_PKG).Version=$(VERSION) -X $(VERSION_PKG).BuildDate=$(BUILD_DATE) -X $(VERSION_PKG).CommitHash=$(GIT_COMMIT)" ./$(FLINTLOCK_METRICS_CMD)
 
+.PHONY: release-snapshot
+release-snapshot: ## Build a local goreleaser snapshot release (binaries + deb/rpm packages), no publishing
+	goreleaser release --snapshot --clean
+
 ##@ Generate
 
 .PHONY: generate

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -68,6 +68,26 @@ buf push --tag "${RELEASE_VERSION}"
 If you get the message `The latest commit has the same content; not creating a new commit.`
 then it means there hasn't been changes to the API so you didn't need to do this.
 
+## Package artifacts
+
+As well as the raw `flintlockd`/`flintlock-metrics` binaries, the release workflow (via
+[goreleaser](https://goreleaser.com/) and its [nfpm](https://nfpm.goreleaser.com/) integration)
+builds `.deb` and `.rpm` packages for both binaries, for `amd64` and `arm64`.
+
+The `flintlockd` package also installs the `flintlockd.service` systemd unit. It does **not**
+declare `containerd` or `firecracker` as package dependencies — their package names and
+availability vary too much across distros (firecracker in particular is rarely packaged), so this
+is enforced by neither `apt`/`dnf`. Make sure user-facing docs (e.g. the quick-start guide) keep
+calling out that both must be installed separately for `flintlockd` to run.
+
+You can test the packaging locally without publishing a release by running:
+
+```bash
+make release-snapshot
+```
+
+which populates `dist/` with the binaries and `.deb`/`.rpm` packages.
+
 ## Announce release
 
 When the release is available announce it in the #liquid-metal slack channel.

--- a/hack/packaging/flintlockd-postinstall.sh
+++ b/hack/packaging/flintlockd-postinstall.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl daemon-reload || true
+fi


### PR DESCRIPTION
## Summary

- Adopts [goreleaser](https://goreleaser.com/) (with its [nfpm](https://nfpm.goreleaser.com/) integration) to replace the current Makefile-build + `softprops/action-gh-release` pipeline, so tagged releases now also attach `.deb`/`.rpm` packages for `flintlockd` and `flintlock-metrics` (amd64/arm64), alongside the existing raw binaries.
- `flintlockd`'s package installs the binary to `/usr/local/bin` and ships the existing `flintlockd.service` systemd unit (with a `daemon-reload` postinstall hook).
- `containerd`/`firecracker` are documented as runtime requirements rather than declared as hard package dependencies, since their package names/availability vary a lot across distro repos (firecracker in particular is rarely packaged) — see the updated `docs/releasing.md`.
- Added `make release-snapshot` for local dry-run testing of the packaging without publishing.

Closes #8

## Test plan

- [x] `goreleaser check` passes against `.goreleaser.yaml`
- [x] `make release-snapshot` locally builds binaries + `.deb`/`.rpm` for both packages/archs
- [x] Inspected `.deb` contents (`ar`/`tar`) — binary at `/usr/local/bin/flintlockd`, unit at `/lib/systemd/system/flintlockd.service`, `postinst` present
- [x] Installed the built `.deb` in a throwaway `debian:12` container — `flintlockd version` runs and the systemd unit is in place
- [ ] Verify the updated `release.yml` workflow succeeds end-to-end on a real tag push