### PR TITLE
docs: refresh README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Flintlock - Create and manage the lifecycle of MicroVMs, backed by containerd.
 
 [![GitHub](https://img.shields.io/github/license/liquidmetal-dev/flintlock)](https://img.shields.io/github/license/liquidmetal-dev/flintlock)
-[![codecov](https://codecov.io/gh/liquidmetal-dev/flintlock/branch/main/graph/badge.svg?token=ZNPNRDI8Z0)](https://codecov.io/gh/liquidmetal-dev/flintlock)
-[![Go Report Card](https://goreportcard.com/badge/github.com/liquidmetal-dev/flintlock)](https://goreportcard.com/report/github.com/liquidmetal-dev/flintlock)
+[![Tests](https://github.com/liquidmetal-dev/flintlock/actions/workflows/test.yml/badge.svg)](https://github.com/liquidmetal-dev/flintlock/actions/workflows/test.yml)
+[![Go Reference](https://pkg.go.dev/badge/github.com/liquidmetal-dev/flintlock.svg)](https://pkg.go.dev/github.com/liquidmetal-dev/flintlock)
+[![GitHub release](https://img.shields.io/github/v/release/liquidmetal-dev/flintlock)](https://github.com/liquidmetal-dev/flintlock/releases/latest)
 
 ## What is flintlock?
 


### PR DESCRIPTION
## Summary
- Remove the codecov badge — coverage reporting has been disabled since #1030 ("Codecov integration isn't enabled for the repo"), so the badge showed stale/dead data.
- Add CI test-status badge (from the `test.yml` workflow), a Go Reference (pkg.go.dev) badge, and a latest-release badge.
- Remove the Go Report Card badge.

## Test plan
- [x] Verified each new badge image URL returns HTTP 200
- [x] Confirmed codecov upload step is commented out in `.github/workflows/test.yml` (disabled by #1030)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CeHuiPbXhA4zLfD6GKTgKm