### PR TITLE
feat: support Cloud Hypervisor v53.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The table below shows you which versions of Firecracker are compatible with Flin
 
 | Flintlock         | Firecracker                      | Cloud Hypervisor  |
 | ----------------- | -------------------------------- | ----------------- |
-| v0.9.x            | Official v1.11+                  | v41.0             |
+| v0.9.x            | Official v1.11+                  | v41.0 - v53.0     |
 | v0.8.x            | Official v1.10+                  | v41.0             |
 | v0.7.0            | Official v1.10+                  | v41.0             |
 | v0.6.0            | Official v1.0+ or v1.0.0-macvtap | v26.0             |

--- a/pkg/cloudhypervisor/types.go
+++ b/pkg/cloudhypervisor/types.go
@@ -35,12 +35,11 @@ type VMConfig struct {
 	Balloon  *BalloonConfig  `json:"balloon,omitempty"`
 	Fs       []FsConfig      `json:"fs,omitempty"`
 	Pmem     []PmemConfig    `json:"pmem,omitempty"`
-	Serial   *ConsoleConfig  `json:"serial,omitempty"`
+	Serial   *SerialConfig   `json:"serial,omitempty"`
 	Console  *ConsoleConfig  `json:"console,omitempty"`
 	Devices  []DeviceConfig  `json:"devices,omitempty"`
 	Vdpa     []VdpaConfig    `json:"vdpa,omitempty"`
 	Vsock    *VsockConfig    `json:"vsock,omitempty"`
-	SgxEpc   []SgxEpcConfig  `json:"sgx_epc,omitempty"`
 	Tdx      *TdxConfig      `json:"tdx,omitempty"`
 	Numa     []NumaConfig    `json:"numa,omitempty"`
 	Iommu    *bool           `json:"iommu,omitempty"`
@@ -59,11 +58,12 @@ type BalloonConfig struct {
 type ConsoleMode string
 
 var (
-	ConsoleModeOff  ConsoleMode = "Off"
-	ConsoleModePty  ConsoleMode = "Pty"
-	ConsoleModeTty  ConsoleMode = "Tty"
-	ConsoleModeFile ConsoleMode = "File"
-	ConsoleModeNull ConsoleMode = "Null"
+	ConsoleModeOff    ConsoleMode = "Off"
+	ConsoleModePty    ConsoleMode = "Pty"
+	ConsoleModeTty    ConsoleMode = "Tty"
+	ConsoleModeFile   ConsoleMode = "File"
+	ConsoleModeSocket ConsoleMode = "Socket"
+	ConsoleModeNull   ConsoleMode = "Null"
 )
 
 // ConsoleConfig represents the configuration for the console.
@@ -71,6 +71,14 @@ type ConsoleConfig struct {
 	File  *string     `json:"file,omitempty"`
 	Mode  ConsoleMode `json:"mode"`
 	Iommu *bool       `json:"iommu,omitempty"`
+}
+
+// SerialConfig represents the configuration for the serial device.
+type SerialConfig struct {
+	File   *string     `json:"file,omitempty"`
+	Mode   ConsoleMode `json:"mode"`
+	Iommu  *bool       `json:"iommu,omitempty"`
+	Socket *string     `json:"socket,omitempty"`
 }
 
 // CPUAffinity is used to specify CPU affinity.
@@ -192,11 +200,10 @@ type NetConfig struct {
 
 // NumaConfig is the NUMA configuration for a VM.
 type NumaConfig struct {
-	GuestNumaID    int32          `json:"guest_numa_id"`
-	Cpus           []int32        `json:"cpus,omitempty"`
-	Distances      []NumaDistance `json:"distances,omitempty"`
-	MemoryZones    []string       `json:"memory_zones,omitempty"`
-	SgxEpcSections []string       `json:"sgx_epc_sections,omitempty"`
+	GuestNumaID int32          `json:"guest_numa_id"`
+	Cpus        []int32        `json:"cpus,omitempty"`
+	Distances   []NumaDistance `json:"distances,omitempty"`
+	MemoryZones []string       `json:"memory_zones,omitempty"`
 }
 
 // NumaDistance represents the NUMA distance.
@@ -265,13 +272,6 @@ type RngConfig struct {
 type SendMigrationData struct {
 	DestinationURL string `json:"destination_url"`
 	Local          *bool  `json:"local,omitempty"`
-}
-
-// SgxEpcConfig is the SGX configuration.
-type SgxEpcConfig struct {
-	ID       string `json:"id"`
-	Size     int64  `json:"size"`
-	Prefault *bool  `json:"prefault,omitempty"`
 }
 
 // TdxConfig is the TDX configuration.


### PR DESCRIPTION
## Summary
- Support Cloud Hypervisor v53.0 as the latest compatible release, alongside the existing v41.0 baseline.
- `pkg/cloudhypervisor/types.go`: remove `VMConfig.SgxEpc`/`SgxEpcConfig`/`NumaConfig.SgxEpcSections` (removed from CH's schema between v41.0 and v53.0, and unused elsewhere in flintlock) and split `VMConfig.Serial` into its own `SerialConfig` type (adds `Socket` mode), matching CH's new schema.
- `README.md`: bump the documented Cloud Hypervisor compatibility range for v0.9.x to `v41.0 - v53.0`.

This is a minimal version-bump PR. Flintlock launches cloud-hypervisor via CLI args rather than the REST `vm.create` body, so the compatibility surface that actually matters (CLI args, `vm.info`/`vm.counters` polling) is unchanged between v41.0 and v53.0 — these type changes are hygiene fixes to keep the (currently unused-for-create) API client accurate.

Deferred feature-adoption work tracked separately:
- #1183 — adopt `/vm.resize-disk`
- #1184 — adopt `/vm.add-generic-vhost-user`
- #1186 — broaden schema coverage (PCI device IDs, NIC offload flags, PlatformConfig additions, etc.)
- #1187 — migrate off deprecated legacy SMBIOS platform keys

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/cloudhypervisor/... ./infrastructure/microvm/cloudhypervisor/...`
- [ ] Manual smoke test against a real cloud-hypervisor v53.0 binary (create/boot/delete a microVM) — not yet performed, draft until verified
