### PR TITLE
chore: bump CI to Firecracker v1.16.1 and refresh compat docs

### DIFF
--- a/.github/workflows/hosted_e2e.yml
+++ b/.github/workflows/hosted_e2e.yml
@@ -65,6 +65,8 @@ jobs:
       - name: Cleanup e2e resources
         if: always()
         run: |
+          sudo ip link delete fl-e2e-br0 type bridge || true
+
           sudo dmsetup remove --force dev-thinpool-e2e || true
 
           while IFS=: read -r device _; do

--- a/.github/workflows/hosted_e2e.yml
+++ b/.github/workflows/hosted_e2e.yml
@@ -6,7 +6,7 @@ on:
       firecracker_version:
         description: "Firecracker release tag to install"
         required: false
-        default: "v1.15.1"
+        default: "v1.16.1"
 
 permissions:
   contents: read
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install Firecracker
         env:
-          FIRECRACKER: ${{ github.event.inputs.firecracker_version || 'v1.15.1' }}
+          FIRECRACKER: ${{ github.event.inputs.firecracker_version || 'v1.16.1' }}
         run: sudo -E ./hack/scripts/provision.sh firecracker
 
       - name: Verify KVM access

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The table below shows you which versions of Firecracker are compatible with Flin
 
 | Flintlock         | Firecracker                      | Cloud Hypervisor  |
 | ----------------- | -------------------------------- | ----------------- |
+| main (unreleased) | Official v1.16.1                 | v41.0             |
 | v0.9.x            | Official v1.11+                  | v41.0             |
 | v0.8.x            | Official v1.10+                  | v41.0             |
 | v0.7.0            | Official v1.10+                  | v41.0             |

--- a/infrastructure/microvm/firecracker/testdata/vm_config.json
+++ b/infrastructure/microvm/firecracker/testdata/vm_config.json
@@ -18,7 +18,7 @@
   "machine-config": {
     "vcpu_count": 2,
     "mem_size_mib": 1024,
-    "ht_enabled": false,
+    "smt": false,
     "track_dirty_pages": false
   },
   "balloon": null,

--- a/infrastructure/microvm/firecracker/types_test.go
+++ b/infrastructure/microvm/firecracker/types_test.go
@@ -26,6 +26,18 @@ func TestUnmarshallWithFCSample(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	if cfg.MachineConfig.VcpuCount != 2 {
+		t.Fatalf("expected vcpu_count to be 2, got: %d", cfg.MachineConfig.VcpuCount)
+	}
+
+	if cfg.MachineConfig.MemSizeMib != 1024 {
+		t.Fatalf("expected mem_size_mib to be 1024, got: %d", cfg.MachineConfig.MemSizeMib)
+	}
+
+	if cfg.MachineConfig.SMT {
+		t.Fatalf("expected smt to be false, got: %t", cfg.MachineConfig.SMT)
+	}
 }
 
 func TestVmmConfig_CPUConfigMarshalling(t *testing.T) {

--- a/test/e2e/utils/runner.go
+++ b/test/e2e/utils/runner.go
@@ -33,6 +33,7 @@ const (
 	devMapperRoot      = containerdRootDir + "/snapshotter/devmapper"
 	grpcDialTarget     = "127.0.0.1:9090"
 	loopDeviceTag      = "e2e"
+	bridgeName         = "fl-e2e-br0"
 )
 
 // Runner holds test runner configuration.
@@ -64,6 +65,7 @@ func NewRunner(params *Params) Runner {
 func (r *Runner) Setup() v1alpha1.MicroVMClient {
 	makeDirectories()
 	r.createThinPools()
+	r.createBridge()
 	r.writeContainerdConfig()
 	r.buildFLBinary()
 	r.startContainerd()
@@ -101,6 +103,7 @@ func (r *Runner) Teardown() {
 		r.containerdSession.Terminate().Wait()
 	}
 
+	deleteBridge()
 	r.cleanupThinPools()
 	cleanupDirectories()
 
@@ -148,6 +151,37 @@ func (r *Runner) cleanupThinPools() {
 		gm.Expect(err).NotTo(gm.HaveOccurred())
 		gm.Eventually(session).Should(gexec.Exit(0))
 	}
+}
+
+func (r *Runner) createBridge() {
+	if !bridgeExists() {
+		addCmd := exec.Command("ip", "link", "add", bridgeName, "type", "bridge")
+		addSession, err := gexec.Start(addCmd, gk.GinkgoWriter, gk.GinkgoWriter)
+		gm.Expect(err).NotTo(gm.HaveOccurred())
+		gm.Eventually(addSession).Should(gexec.Exit(0))
+	}
+
+	upCmd := exec.Command("ip", "link", "set", bridgeName, "up")
+	upSession, err := gexec.Start(upCmd, gk.GinkgoWriter, gk.GinkgoWriter)
+	gm.Expect(err).NotTo(gm.HaveOccurred())
+	gm.Eventually(upSession).Should(gexec.Exit(0))
+}
+
+func bridgeExists() bool {
+	cmd := exec.Command("ip", "link", "show", bridgeName)
+
+	return cmd.Run() == nil
+}
+
+func deleteBridge() {
+	if !bridgeExists() {
+		return
+	}
+
+	command := exec.Command("ip", "link", "delete", bridgeName, "type", "bridge")
+	session, err := gexec.Start(command, gk.GinkgoWriter, gk.GinkgoWriter)
+	gm.Expect(err).NotTo(gm.HaveOccurred())
+	gm.Eventually(session).Should(gexec.Exit(0))
 }
 
 func (r *Runner) writeContainerdConfig() {
@@ -209,6 +243,7 @@ func (r *Runner) startFlintlockd() {
 	flCmd := exec.Command(r.flintlockdBin, "run",
 		"--containerd-socket", containerdSocket,
 		"--parent-iface", parentIface,
+		"--bridge-name", bridgeName,
 		"--verbosity", r.params.FlintlockdLogLevel,
 		"--insecure",
 	)

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -103,7 +103,7 @@ func defaultTestMicroVM(name, namespace string) *types.MicroVMSpec {
 		Interfaces: []*types.NetworkInterface{
 			{
 				DeviceId: "eth1",
-				Type:     0,
+				Type:     types.NetworkInterface_TAP,
 			},
 		},
 		Metadata: map[string]string{


### PR DESCRIPTION
## Summary
- Bumps the `hosted_e2e.yml` default Firecracker version to `v1.16.1`.
- Adds a `main (unreleased)` row to the README compatibility matrix pointing at Firecracker v1.16.1.
- Fixes a stale test fixture (`testdata/vm_config.json`) that used the old `ht_enabled` key instead of `smt`, so the roundtrip unmarshal test in `types_test.go` was silently not exercising the real `machine-config` schema. Added assertions on the unmarshalled values.
- Fixes two pre-existing e2e bugs (unrelated to the version bump, found while verifying this PR):
  - `test/e2e/utils/utils.go` left `NetworkInterface.Type` unset, defaulting to the proto zero-value `MACVTAP`, which the Firecracker provider has never supported.
  - The e2e harness never created a bridge or passed flintlockd's existing (but previously unused by e2e) `--bridge-name` flag, so TAP interfaces (Attach=true by default) had no parent device to attach to. The harness now creates/tears down a dedicated `fl-e2e-br0` bridge.
  - Together these meant every hosted e2e run against the Firecracker provider was failing before VM creation, regardless of Firecracker version.

Per research into the upstream Firecracker changelog (v1.15.x -> v1.16.1), there are no config-file schema breaking changes affecting flintlock's usage (flintlock drives Firecracker via `--config-file`/`--no-api`, not the HTTP API). v1.16.0 added dev-preview PCI hotplug support (opt-in, not used here); v1.16.1 was bug fixes only (logger deadlock, a CPUID/MSR ordering fix on newer host kernels).

MMDS v1 is deprecated upstream in favor of v2 (removal planned for Firecracker v2.0.0). flintlock still hardcodes MMDS v1 — tracked separately in #1185 since it's not required for v1.16.1 compatibility.

## Test plan
- [x] `go build ./...`
- [x] `go test ./infrastructure/microvm/firecracker/...`
- [x] hosted e2e workflow run against Firecracker v1.16.1, full pass (two microVMs created, listed, deleted): https://github.com/liquidmetal-dev/flintlock/actions/runs/33867867393