### PR TITLE
feat: automate publishing schema to Buf Schema Registry

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-tags: true
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - name: Lint
         run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       # from branches within this repo.
       - name: Log in to Buf Schema Registry
         if: github.event.pull_request.head.repo.full_name == github.repository
-        run: buf registry login --username liquidmetal-dev --token "${{ secrets.BUF_TOKEN }}"
+        run: echo "${{ secrets.BUF_TOKEN }}" | buf registry login --token-stdin
       - name: Check for breaking protobuf/grpc changes
         if: github.event.pull_request.head.repo.full_name == github.repository
         run: make proto-breaking

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,3 +11,14 @@ jobs:
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       - name: Lint
         run: make lint
+      - name: Lint protobuf/grpc
+        run: make proto-lint
+      # buf breaking needs BSR auth to resolve the module, and secrets aren't
+      # available to fork-originated pull requests, so only run it for PRs
+      # from branches within this repo.
+      - name: Log in to Buf Schema Registry
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: buf registry login --username liquidmetal-dev --token "${{ secrets.BUF_TOKEN }}"
+      - name: Check for breaking protobuf/grpc changes
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        run: make proto-breaking

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,3 +38,7 @@ jobs:
       run: goreleaser release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Log in to Buf Schema Registry
+      run: buf registry login --username liquidmetal-dev --token "${{ secrets.BUF_TOKEN }}"
+    - name: Push schema to Buf Schema Registry
+      run: buf push --tag "${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Log in to Buf Schema Registry
-      run: buf registry login --username liquidmetal-dev --token "${{ secrets.BUF_TOKEN }}"
+      run: echo "${{ secrets.BUF_TOKEN }}" | buf registry login --token-stdin
     - name: Push schema to Buf Schema Registry
       run: buf push --tag "${{ github.ref_name }}"

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,10 @@ lint-fix: ## Lint the codebase and run auto-fixers if supported by the linter
 proto-lint: ## Lint protobuf/grpc
 	buf lint
 
+.PHONY: proto-breaking
+proto-breaking: ## Check protobuf/grpc for breaking changes against the published BSR schema
+	buf breaking --against buf.build/liquidmetal-dev/flintlock
+
 ##@ Testing
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ proto-lint: ## Lint protobuf/grpc
 
 .PHONY: proto-breaking
 proto-breaking: ## Check protobuf/grpc for breaking changes against the published BSR schema
-	buf breaking --against buf.build/liquidmetal-dev/flintlock
+	buf breaking --against buf.build/liquidmetal-dev/flintlock:main
 
 ##@ Testing
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -42,31 +42,15 @@ git push origin "${RELEASE_VERSION}"
 - If this is a pre-release tick `This is a pre-release`
 - Publish the draft release and when asked say yes to creating a discussion.
 
-## Commit a new `buf` tag
+## Buf Schema Registry publish
 
 We have gRPC API docs hosted on [buf.build](https://buf.build/liquidmetal-dev/flintlock).
-If the API has changed, you'll need to update these.
+The [release](https://github.com/liquidmetal-dev/flintlock/actions/workflows/release.yml) workflow
+automatically logs in to the Buf Schema Registry and runs `buf push --tag "${RELEASE_VERSION}"` for
+every tag push, so no manual step is required here.
 
-Log in creds can be found in the shared Team Quicksilver 1Pass vault.
-
-Generate a new token.
-
-Log in locally:
-
-```
-buf registry login
-# username is liquidmetal-dev
-# key is the token you generated
-```
-
-Push a new tag:
-
-```
-buf push --tag "${RELEASE_VERSION}"
-```
-
-If you get the message `The latest commit has the same content; not creating a new commit.`
-then it means there hasn't been changes to the API so you didn't need to do this.
+If you see `The latest commit has the same content; not creating a new commit.` in the workflow
+logs, it just means there were no proto changes to publish for this release.
 
 ## Package artifacts
 


### PR DESCRIPTION
## Summary
- Automate `buf push` in `release.yml` so the schema is published to BSR on every release tag, replacing the manual step previously documented in `docs/releasing.md`
- Add `buf lint` and `buf breaking` (against the published BSR schema) to `lint.yml` so proto changes are validated on every PR; the breaking check is skipped for fork-originated PRs since they don't have access to `BUF_TOKEN`
- Add a `proto-breaking` Makefile target alongside the existing `proto-lint`
- Update `docs/releasing.md` to remove the now-automated manual buf push instructions
- Seeded the BSR module's `main` label with an initial `buf push` (it previously had no commits, so `buf breaking` had nothing to compare against)

Closes #1192

## Test plan
- [x] `make proto-lint` passes locally
- [x] `make proto-breaking` passes locally against the live BSR module
- [x] Workflow YAML validated for syntax
- [ ] Confirm `lint.yml` runs `buf lint`/`buf breaking` successfully on this PR
- [ ] Confirm `release.yml` pushes to BSR successfully on the next tag release
