### PR TITLE
fix(exec): bound guest-agent exec session reads with an idle deadline

### DIFF
--- a/infrastructure/vsockexec/client.go
+++ b/infrastructure/vsockexec/client.go
@@ -6,10 +6,14 @@ package vsockexec
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/liquidmetal-dev/guest-agent/pkg/vsockclient"
+
+	"github.com/liquidmetal-dev/flintlock/pkg/defaults"
 )
 
 // EventType identifies what a Session.Next event carries.
@@ -38,7 +42,8 @@ type Event struct {
 // Session is one exec request/response exchange with a guest-agent's control
 // channel, reached by dialling a vsock UDS multiplexer path.
 type Session struct {
-	conn net.Conn
+	conn        net.Conn
+	idleTimeout time.Duration
 }
 
 // Start dials udsPath (a Firecracker/Cloud Hypervisor vsock UDS multiplexer)
@@ -57,7 +62,14 @@ func Start(ctx context.Context, udsPath string, controlPort uint32, exec *vsockc
 		return nil, fmt.Errorf("sending exec request: %w", err)
 	}
 
-	return &Session{conn: conn}, nil
+	return &Session{conn: conn, idleTimeout: defaults.ExecSessionIdleTimeout}, nil
+}
+
+// SetIdleTimeout overrides the default idle deadline Next() applies to each
+// read. Mainly useful for tests that need to exercise the timeout path
+// without waiting out the real default.
+func (s *Session) SetIdleTimeout(d time.Duration) {
+	s.idleTimeout = d
 }
 
 // SendStdin forwards p to the running command's stdin.
@@ -80,10 +92,23 @@ func (s *Session) CloseStdin() error {
 
 // Next blocks for the next frame from the guest-agent and translates it into
 // an Event. EventExit always ends the exchange.
+//
+// The underlying read carries an idle deadline: some vsock transports don't
+// reliably deliver EOF/RST to the host side when the guest-agent closes its
+// end, which would otherwise block this call forever.
 func (s *Session) Next() (Event, error) {
 	for {
+		if err := s.conn.SetReadDeadline(time.Now().Add(s.idleTimeout)); err != nil {
+			return Event{}, fmt.Errorf("setting exec session read deadline: %w", err)
+		}
+
 		f, err := vsockclient.ReadFrame(s.conn)
 		if err != nil {
+			var netErr net.Error
+			if errors.As(err, &netErr) && netErr.Timeout() {
+				return Event{}, fmt.Errorf("guest-agent exec session timed out waiting for next frame: %w", err)
+			}
+
 			return Event{}, fmt.Errorf("reading guest-agent frame: %w", err)
 		}
 

--- a/infrastructure/vsockexec/client.go
+++ b/infrastructure/vsockexec/client.go
@@ -42,7 +42,11 @@ type Event struct {
 // Session is one exec request/response exchange with a guest-agent's control
 // channel, reached by dialling a vsock UDS multiplexer path.
 type Session struct {
-	conn        net.Conn
+	conn net.Conn
+	// idleTimeout is the deadline Next() applies to each read. Zero means no
+	// deadline: the request's TimeoutSec was unbounded (0), so there's no
+	// budget to derive one from and imposing an arbitrary one would risk
+	// cutting off a healthy, merely quiet command.
 	idleTimeout time.Duration
 }
 
@@ -62,12 +66,17 @@ func Start(ctx context.Context, udsPath string, controlPort uint32, exec *vsockc
 		return nil, fmt.Errorf("sending exec request: %w", err)
 	}
 
-	return &Session{conn: conn, idleTimeout: defaults.ExecSessionIdleTimeout}, nil
+	var idleTimeout time.Duration
+	if exec.TimeoutSec > 0 {
+		idleTimeout = time.Duration(exec.TimeoutSec)*time.Second + defaults.ExecSessionIdleGrace
+	}
+
+	return &Session{conn: conn, idleTimeout: idleTimeout}, nil
 }
 
-// SetIdleTimeout overrides the default idle deadline Next() applies to each
-// read. Mainly useful for tests that need to exercise the timeout path
-// without waiting out the real default.
+// SetIdleTimeout overrides the idle deadline Next() applies to each read.
+// Mainly useful for tests that need to exercise the timeout path without
+// waiting out the real one derived from the exec request's TimeoutSec.
 func (s *Session) SetIdleTimeout(d time.Duration) {
 	s.idleTimeout = d
 }
@@ -93,13 +102,19 @@ func (s *Session) CloseStdin() error {
 // Next blocks for the next frame from the guest-agent and translates it into
 // an Event. EventExit always ends the exchange.
 //
-// The underlying read carries an idle deadline: some vsock transports don't
-// reliably deliver EOF/RST to the host side when the guest-agent closes its
-// end, which would otherwise block this call forever.
+// When the exec request set a TimeoutSec, each read carries a deadline of
+// TimeoutSec-plus-grace: the guest-agent enforces TimeoutSec itself and
+// should respond by then, so a read timing out past that means the
+// connection is wedged (some vsock transports don't reliably deliver
+// EOF/RST to the host side when the guest-agent closes its end) rather than
+// the command just being quiet. Requests with no TimeoutSec get no deadline,
+// since there's then no way to tell a healthy quiet command from a dead one.
 func (s *Session) Next() (Event, error) {
 	for {
-		if err := s.conn.SetReadDeadline(time.Now().Add(s.idleTimeout)); err != nil {
-			return Event{}, fmt.Errorf("setting exec session read deadline: %w", err)
+		if s.idleTimeout > 0 {
+			if err := s.conn.SetReadDeadline(time.Now().Add(s.idleTimeout)); err != nil {
+				return Event{}, fmt.Errorf("setting exec session read deadline: %w", err)
+			}
 		}
 
 		f, err := vsockclient.ReadFrame(s.conn)

--- a/infrastructure/vsockexec/client.go
+++ b/infrastructure/vsockexec/client.go
@@ -43,11 +43,31 @@ type Event struct {
 // channel, reached by dialling a vsock UDS multiplexer path.
 type Session struct {
 	conn net.Conn
-	// idleTimeout is the deadline Next() applies to each read. Zero means no
-	// deadline: the request's TimeoutSec was unbounded (0), so there's no
-	// budget to derive one from and imposing an arbitrary one would risk
-	// cutting off a healthy, merely quiet command.
+	// idleTimeout is the deadline Next() applies to each read; see
+	// idleTimeoutFor for how it's derived.
 	idleTimeout time.Duration
+}
+
+// idleTimeoutFor derives the idle read deadline for an exec session from the
+// request's TimeoutSec:
+//
+//   - TimeoutSec > 0: the guest-agent enforces it itself and is expected to
+//     report an outcome by then, so TimeoutSec-plus-grace bounds how long the
+//     guest-agent should legitimately take to respond, not how long the
+//     command may stay quiet.
+//   - TimeoutSec == 0 ("unbounded" per the exec protocol): there's no
+//     declared budget to derive a deadline from, and no protocol-level way
+//     to tell a healthy quiet command (e.g. a long sleep) from a wedged
+//     connection. Rather than leave the read able to block forever — which
+//     is the failure mode being guarded against — fall back to a generous
+//     ceiling: a last-resort circuit breaker, not a liveness check, so it's
+//     sized to basically never trip a real quiet workload.
+func idleTimeoutFor(timeoutSec int) time.Duration {
+	if timeoutSec > 0 {
+		return time.Duration(timeoutSec)*time.Second + defaults.ExecSessionIdleGrace
+	}
+
+	return defaults.ExecSessionUnboundedIdleCeiling
 }
 
 // Start dials udsPath (a Firecracker/Cloud Hypervisor vsock UDS multiplexer)
@@ -66,12 +86,7 @@ func Start(ctx context.Context, udsPath string, controlPort uint32, exec *vsockc
 		return nil, fmt.Errorf("sending exec request: %w", err)
 	}
 
-	var idleTimeout time.Duration
-	if exec.TimeoutSec > 0 {
-		idleTimeout = time.Duration(exec.TimeoutSec)*time.Second + defaults.ExecSessionIdleGrace
-	}
-
-	return &Session{conn: conn, idleTimeout: idleTimeout}, nil
+	return &Session{conn: conn, idleTimeout: idleTimeoutFor(exec.TimeoutSec)}, nil
 }
 
 // SetIdleTimeout overrides the idle deadline Next() applies to each read.
@@ -102,13 +117,10 @@ func (s *Session) CloseStdin() error {
 // Next blocks for the next frame from the guest-agent and translates it into
 // an Event. EventExit always ends the exchange.
 //
-// When the exec request set a TimeoutSec, each read carries a deadline of
-// TimeoutSec-plus-grace: the guest-agent enforces TimeoutSec itself and
-// should respond by then, so a read timing out past that means the
-// connection is wedged (some vsock transports don't reliably deliver
-// EOF/RST to the host side when the guest-agent closes its end) rather than
-// the command just being quiet. Requests with no TimeoutSec get no deadline,
-// since there's then no way to tell a healthy quiet command from a dead one.
+// Each read carries an idle deadline (see idleTimeoutFor) so a wedged
+// connection surfaces as an error instead of blocking forever — some vsock
+// transports don't reliably deliver EOF/RST to the host side when the
+// guest-agent closes its end.
 func (s *Session) Next() (Event, error) {
 	for {
 		if s.idleTimeout > 0 {

--- a/infrastructure/vsockexec/client_test.go
+++ b/infrastructure/vsockexec/client_test.go
@@ -123,8 +123,9 @@ func TestSession_ExecStdoutStderrExit(t *testing.T) {
 // https://github.com/liquidmetal-dev/flintlock/issues/1200: the guest-agent
 // responds to the exec request and then never sends an exit frame and never
 // closes the connection (as observed with some vsock-over-UDS transports
-// after a guest-side RST that never reaches the host as EOF). Next() must
-// return an error within the idle timeout instead of blocking forever.
+// after a guest-side RST that never reaches the host as EOF). For a bounded
+// request (TimeoutSec > 0), Next() must return an error within the idle
+// deadline instead of blocking forever.
 func TestSession_Next_TimesOutWhenGuestAgentGoesQuiet(t *testing.T) {
 	const port = 1024
 
@@ -143,12 +144,14 @@ func TestSession_Next_TimesOutWhenGuestAgentGoesQuiet(t *testing.T) {
 	})
 	t.Cleanup(func() { close(stuck) })
 
-	session, err := vsockexec.Start(context.Background(), udsPath, port, &vsockclient.Exec{Cmd: "uname"})
+	session, err := vsockexec.Start(context.Background(), udsPath, port, &vsockclient.Exec{Cmd: "uname", TimeoutSec: 1})
 	if err != nil {
 		t.Fatalf("Start: %v", err)
 	}
 	defer session.Close()
 
+	// Override the real TimeoutSec-derived deadline (1s + 30s grace) so the
+	// test doesn't have to wait over 30 seconds for it to fire.
 	session.SetIdleTimeout(100 * time.Millisecond)
 
 	event, err := session.Next()
@@ -175,6 +178,75 @@ func TestSession_Next_TimesOutWhenGuestAgentGoesQuiet(t *testing.T) {
 
 	if nextErr == nil {
 		t.Fatal("Next: expected a timeout error, got nil")
+	}
+}
+
+// TestSession_Next_HealthyQuietCommandDoesNotTimeOut guards against the
+// idle deadline killing a healthy command that simply produces no output
+// for a while (e.g. `sleep`) but finishes well within its own TimeoutSec.
+// Before deriving the deadline from TimeoutSec, a flat idle timeout shorter
+// than the quiet interval would fail this the same way it fails a genuinely
+// wedged connection.
+func TestSession_Next_HealthyQuietCommandDoesNotTimeOut(t *testing.T) {
+	const port = 1024
+
+	udsPath := fakeGuestAgent(t, port, func(conn net.Conn) {
+		defer conn.Close()
+
+		if _, err := vsockclient.ReadFrame(conn); err != nil {
+			return
+		}
+
+		// Quiet interval intentionally longer than the idle timeout that
+		// would apply if it weren't derived from a generous TimeoutSec.
+		time.Sleep(250 * time.Millisecond)
+		vsockclient.WriteExit(conn, 0)
+	})
+
+	session, err := vsockexec.Start(context.Background(), udsPath, port, &vsockclient.Exec{Cmd: "sleep", TimeoutSec: 5})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer session.Close()
+
+	event, err := session.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if event.Type != vsockexec.EventExit || event.ExitCode != 0 {
+		t.Fatalf("unexpected event: %+v", event)
+	}
+}
+
+// TestSession_Next_UnboundedTimeoutSecAppliesNoDeadline confirms a request
+// with TimeoutSec == 0 (documented as unbounded) gets no idle deadline at
+// all, since there's no declared budget to derive one from.
+func TestSession_Next_UnboundedTimeoutSecAppliesNoDeadline(t *testing.T) {
+	const port = 1024
+
+	udsPath := fakeGuestAgent(t, port, func(conn net.Conn) {
+		defer conn.Close()
+
+		if _, err := vsockclient.ReadFrame(conn); err != nil {
+			return
+		}
+
+		time.Sleep(250 * time.Millisecond)
+		vsockclient.WriteExit(conn, 0)
+	})
+
+	session, err := vsockexec.Start(context.Background(), udsPath, port, &vsockclient.Exec{Cmd: "sleep"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer session.Close()
+
+	event, err := session.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if event.Type != vsockexec.EventExit || event.ExitCode != 0 {
+		t.Fatalf("unexpected event: %+v", event)
 	}
 }
 

--- a/infrastructure/vsockexec/client_test.go
+++ b/infrastructure/vsockexec/client_test.go
@@ -218,10 +218,13 @@ func TestSession_Next_HealthyQuietCommandDoesNotTimeOut(t *testing.T) {
 	}
 }
 
-// TestSession_Next_UnboundedTimeoutSecAppliesNoDeadline confirms a request
-// with TimeoutSec == 0 (documented as unbounded) gets no idle deadline at
-// all, since there's no declared budget to derive one from.
-func TestSession_Next_UnboundedTimeoutSecAppliesNoDeadline(t *testing.T) {
+// TestSession_Next_UnboundedTimeoutSecToleratesAQuietCommand confirms a
+// request with TimeoutSec == 0 (documented as unbounded) still completes
+// normally through a short quiet interval, rather than falling back to a
+// deadline tight enough to fire on ordinary quiet output gaps. The much
+// larger circuit-breaker ceiling for this case is covered directly by
+// TestIdleTimeoutFor.
+func TestSession_Next_UnboundedTimeoutSecToleratesAQuietCommand(t *testing.T) {
 	const port = 1024
 
 	udsPath := fakeGuestAgent(t, port, func(conn net.Conn) {

--- a/infrastructure/vsockexec/client_test.go
+++ b/infrastructure/vsockexec/client_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/liquidmetal-dev/guest-agent/pkg/vsockclient"
 
@@ -115,6 +116,65 @@ func TestSession_ExecStdoutStderrExit(t *testing.T) {
 	}
 	if gotExit != 7 {
 		t.Errorf("exit code = %d, want 7", gotExit)
+	}
+}
+
+// TestSession_Next_TimesOutWhenGuestAgentGoesQuiet reproduces the hang from
+// https://github.com/liquidmetal-dev/flintlock/issues/1200: the guest-agent
+// responds to the exec request and then never sends an exit frame and never
+// closes the connection (as observed with some vsock-over-UDS transports
+// after a guest-side RST that never reaches the host as EOF). Next() must
+// return an error within the idle timeout instead of blocking forever.
+func TestSession_Next_TimesOutWhenGuestAgentGoesQuiet(t *testing.T) {
+	const port = 1024
+
+	stuck := make(chan struct{})
+
+	udsPath := fakeGuestAgent(t, port, func(conn net.Conn) {
+		if _, err := vsockclient.ReadFrame(conn); err != nil {
+			return
+		}
+
+		vsockclient.WriteFrame(conn, vsockclient.FrameStdout, []byte("hello stdout"))
+
+		// Simulate a guest-agent that has gone quiet without closing the
+		// connection or sending an exit frame.
+		<-stuck
+	})
+	t.Cleanup(func() { close(stuck) })
+
+	session, err := vsockexec.Start(context.Background(), udsPath, port, &vsockclient.Exec{Cmd: "uname"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer session.Close()
+
+	session.SetIdleTimeout(100 * time.Millisecond)
+
+	event, err := session.Next()
+	if err != nil {
+		t.Fatalf("Next: unexpected error on first frame: %v", err)
+	}
+	if event.Type != vsockexec.EventStdout {
+		t.Fatalf("unexpected first event: %+v", event)
+	}
+
+	done := make(chan struct{})
+	var nextErr error
+
+	go func() {
+		defer close(done)
+		_, nextErr = session.Next()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Next() blocked forever instead of timing out")
+	}
+
+	if nextErr == nil {
+		t.Fatal("Next: expected a timeout error, got nil")
 	}
 }
 

--- a/infrastructure/vsockexec/idle_timeout_internal_test.go
+++ b/infrastructure/vsockexec/idle_timeout_internal_test.go
@@ -1,0 +1,40 @@
+package vsockexec
+
+import (
+	"testing"
+	"time"
+
+	"github.com/liquidmetal-dev/flintlock/pkg/defaults"
+)
+
+func TestIdleTimeoutFor(t *testing.T) {
+	tests := []struct {
+		name       string
+		timeoutSec int
+		want       time.Duration
+	}{
+		{
+			name:       "unbounded falls back to the ceiling",
+			timeoutSec: 0,
+			want:       defaults.ExecSessionUnboundedIdleCeiling,
+		},
+		{
+			name:       "bounded adds grace on top of TimeoutSec",
+			timeoutSec: 5,
+			want:       5*time.Second + defaults.ExecSessionIdleGrace,
+		},
+		{
+			name:       "longer bounded request still gets the same grace",
+			timeoutSec: 120,
+			want:       120*time.Second + defaults.ExecSessionIdleGrace,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := idleTimeoutFor(tt.timeoutSec); got != tt.want {
+				t.Errorf("idleTimeoutFor(%d) = %v, want %v", tt.timeoutSec, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -92,9 +92,13 @@ const (
 	// GuestAgentSSHPort is the guest-agent's ssh-proxy vsock port.
 	GuestAgentSSHPort = 1025
 
-	// ExecSessionIdleTimeout is the default maximum time to wait for the next
-	// frame from the guest-agent on an exec session before giving up. It
-	// guards against the guest-agent's end of the vsock connection closing
-	// without the host ever observing an EOF/error on the read.
-	ExecSessionIdleTimeout time.Duration = 30 * time.Second
+	// ExecSessionIdleGrace is added on top of an exec request's own
+	// TimeoutSec to get the idle deadline for reads on its exec session: the
+	// guest-agent enforces TimeoutSec itself and is expected to respond by
+	// then, so this is just a buffer for it to report that outcome (plus
+	// network latency) before the host gives up on a wedged connection. Only
+	// applied when TimeoutSec is set; a request with no timeout (0, meaning
+	// unbounded) gets no idle deadline at all, since a healthy quiet command
+	// is indistinguishable from a dead transport without one.
+	ExecSessionIdleGrace time.Duration = 30 * time.Second
 )

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -96,9 +96,16 @@ const (
 	// TimeoutSec to get the idle deadline for reads on its exec session: the
 	// guest-agent enforces TimeoutSec itself and is expected to respond by
 	// then, so this is just a buffer for it to report that outcome (plus
-	// network latency) before the host gives up on a wedged connection. Only
-	// applied when TimeoutSec is set; a request with no timeout (0, meaning
-	// unbounded) gets no idle deadline at all, since a healthy quiet command
-	// is indistinguishable from a dead transport without one.
+	// network latency) before the host gives up on a wedged connection.
 	ExecSessionIdleGrace time.Duration = 30 * time.Second
+
+	// ExecSessionUnboundedIdleCeiling is the idle read deadline for an exec
+	// request with no TimeoutSec (0, "unbounded"). There's no declared
+	// budget to derive a deadline from in that case, and no protocol-level
+	// way to tell a healthy quiet command from a wedged connection, so this
+	// is a last-resort circuit breaker rather than a liveness check: sized
+	// generously so it's not expected to trip a real quiet workload, while
+	// still guaranteeing the session eventually gives up on a dead
+	// transport instead of blocking forever.
+	ExecSessionUnboundedIdleCeiling time.Duration = 15 * time.Minute
 )

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -91,4 +91,10 @@ const (
 
 	// GuestAgentSSHPort is the guest-agent's ssh-proxy vsock port.
 	GuestAgentSSHPort = 1025
+
+	// ExecSessionIdleTimeout is the default maximum time to wait for the next
+	// frame from the guest-agent on an exec session before giving up. It
+	// guards against the guest-agent's end of the vsock connection closing
+	// without the host ever observing an EOF/error on the read.
+	ExecSessionIdleTimeout time.Duration = 30 * time.Second
 )


### PR DESCRIPTION
## Summary

Addresses #1200: `MicroVMExec.ExecCommand` can hang forever once the
guest-agent stops sending frames on its vsock control channel, since
`Session.Next()` (`infrastructure/vsockexec/client.go`) reads with no
deadline. This bounds that blocking instead of eliminating it outright —
see "Open question on root cause" below for why I'm not claiming this is
a proven fix for the exact reported trace.

- Read frames now carry an idle deadline derived from the exec request's
  own `TimeoutSec` (already caller-controlled, no proto change needed):
  - `TimeoutSec > 0`: deadline = `TimeoutSec` + `ExecSessionIdleGrace`
    (30s) — the guest-agent already enforces `TimeoutSec` itself and is
    expected to report an outcome by then, so this only fires once the
    guest-agent should already have responded.
  - `TimeoutSec == 0` ("unbounded"): falls back to
    `ExecSessionUnboundedIdleCeiling` (15m), a last-resort circuit
    breaker rather than a liveness check, sized to not trip a real quiet
    workload while still guaranteeing the session eventually gives up on
    a wedged connection.
- `pkg/defaults`: add both constants.
- `Session.SetIdleTimeout` lets tests exercise the timeout path directly.

### Why not a flat timeout

An earlier version of this PR used a single fixed idle timeout applied
to every read. Review caught that this kills perfectly healthy
commands that are simply quiet for a while (e.g. `sleep 60`, or any
command with `timeout_seconds=120` producing no output) — the
guest-agent sends no heartbeat frames, so a quiet-but-alive command is
indistinguishable on the wire from a dead connection, and closing the
session on a false timeout kills the still-running command. Deriving
the deadline from the request's own declared budget (instead of a
constant) fixes that for bounded requests; the unbounded case still has
no fully principled answer without a guest-agent protocol change
(heartbeat frames), so it gets an explicit, generous circuit breaker
instead.

### Open question on root cause

A review comment worked through the byte counts in the issue's
Firecracker vsock trace and makes a good case that the reported 5-byte
and 10-byte guest writes match a complete `FrameExit` header +
`{"code":0}` payload — i.e. the exit frame likely *did* fully arrive,
and `Session.Next()` returns `EventExit` immediately on decoding it,
without needing EOF at all. If that's what happened, "missing EOF
detection" doesn't actually explain the reported hang, and the real
cause is still open (possibly a host-side vsock-over-UDS receive
edge-case that doesn't reduce to the framing/decoding logic touched
here). I haven't been able to reproduce the original Firecracker
scenario to confirm either way. This PR should be read as bounding the
general failure mode described in the issue (a read that can block
forever) rather than a confirmed fix for that exact trace — closing the
loop on the actual root cause needs a real repro with host-side
visibility into what the vsock UDS multiplexer actually delivers.

## Test plan

- [x] `make test` / `go build ./...`
- [x] `TestSession_Next_TimesOutWhenGuestAgentGoesQuiet` — a bounded
      session whose guest-agent goes silent without closing the
      connection or sending an exit frame times out instead of hanging
- [x] `TestSession_Next_HealthyQuietCommandDoesNotTimeOut` — a bounded
      command that's quiet for longer than the old flat timeout, but
      within its own `TimeoutSec` + grace, still completes successfully
- [x] `TestSession_Next_UnboundedTimeoutSecToleratesAQuietCommand` — an
      unbounded request tolerates an ordinary quiet interval
- [x] `TestIdleTimeoutFor` — direct unit coverage of both branches of the
      deadline derivation
- [x] Existing `TestExecServer_ExecCommand_ContextCancellationClosesSession`
      still passes unmodified