### PR TITLE
feat(lint): add incremental lint-new target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -339,6 +339,22 @@ export CTR_SOCK_PATH=</path/to/containerd.sock>
 make test
 ```
 
+### Linting
+
+To run the full lint suite (the same one CI runs), run:
+
+```bash
+make lint
+```
+
+Since this lints the whole repository with every linter enabled, it can be
+slow. For faster local iteration, `make lint-new` only lints files that have
+changed versus `main`:
+
+```bash
+make lint-new
+```
+
 ### Running the end to end tests
 
 See the dedicated docs for the end to end tests [here](test/e2e/README.md).

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,10 @@ lint:  ## Lint code
 lint-fix: ## Lint the codebase and run auto-fixers if supported by the linter
 	GOLANGCI_LINT_EXTRA_ARGS=--fix $(MAKE) lint
 
+.PHONY: lint-new
+lint-new: ## Lint only files changed vs main (fast local iteration)
+	golangci-lint run -v --new-from-rev=main $(GOLANGCI_LINT_EXTRA_ARGS)
+
 .PHONY: proto-lint
 proto-lint: ## Lint protobuf/grpc
 	buf lint


### PR DESCRIPTION
## Summary

- `make lint` runs golangci-lint with `enable-all: true` (88 linters) over the
  whole repo, which is slow for everyday local iteration.
- Add `make lint-new`, which uses the exact same `.golangci.yml` config but
  scopes the check to files changed versus `main` (`--new-from-rev=main`), so
  local runs only analyze/report on your diff.
- `make lint` and CI's `.github/workflows/lint.yml` are unchanged — they still
  run the full, whole-repo check, so nothing about what gets enforced on a PR
  changes.
- Documented `make lint-new` in `CONTRIBUTING.md`.

This is step 1 of 2 for speeding up local linting; a follow-up PR will look at
trimming genuinely slow, low-value linters from `.golangci.yml` based on
measured per-linter timings.

## Test plan

- [x] Ran `make lint-new` locally on this branch (no Go files changed vs
      main) — completed cleanly with the expected 88 active linters and no
      errors.
- [ ] CI lint job passes on the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)