### PR TITLE
fix(vsockexec): retry transient guest-agent handshake failures

### DIFF
--- a/infrastructure/vsockexec/client.go
+++ b/infrastructure/vsockexec/client.go
@@ -83,7 +83,7 @@ func idleTimeoutFor(timeoutSec int) time.Duration {
 // on the guest-agent's control port and sends an exec request. Callers must
 // call Close when done.
 func Start(ctx context.Context, udsPath string, controlPort uint32, exec *vsockclient.Exec) (*Session, error) {
-	conn, err := vsockclient.Dial(ctx, udsPath, controlPort)
+	conn, err := dialWithRetry(ctx, udsPath, controlPort)
 	if err != nil {
 		return nil, fmt.Errorf("dialling guest-agent control channel: %w", err)
 	}
@@ -100,6 +100,55 @@ func Start(ctx context.Context, udsPath string, controlPort uint32, exec *vsockc
 		idleTimeout:          idleTimeoutFor(exec.TimeoutSec),
 		heartbeatIdleTimeout: defaults.ExecSessionIdleTimeout,
 	}, nil
+}
+
+// dialRetries and dialRetryDelay back dialWithRetry; they default to the
+// package defaults but are overridable by tests via SetDialRetryParams so
+// retry-exhaustion cases don't have to sleep through the real delay.
+var (
+	dialRetries    = defaults.GuestAgentDialRetries
+	dialRetryDelay = defaults.GuestAgentDialRetryDelay
+)
+
+// SetDialRetryParams overrides the retry count/delay dialWithRetry uses,
+// returning a func that restores the previous values. Mainly useful for
+// tests that need to exercise retry exhaustion without waiting out the real
+// delay.
+func SetDialRetryParams(retries int, delay time.Duration) (restore func()) {
+	prevRetries, prevDelay := dialRetries, dialRetryDelay
+	dialRetries, dialRetryDelay = retries, delay
+
+	return func() { dialRetries, dialRetryDelay = prevRetries, prevDelay }
+}
+
+// dialWithRetry dials udsPath/controlPort, retrying up to dialRetries times
+// (with dialRetryDelay between attempts) on failure. Rapid repeated dials
+// against the same vsock port have been observed to occasionally get EOF
+// instead of the CONNECT handshake's OK reply — most likely a transient
+// vsock multiplexer hiccup rather than a genuine failure to connect — so a
+// few quick retries let the handshake ride that out. See
+// defaults.GuestAgentDialRetries.
+func dialWithRetry(ctx context.Context, udsPath string, controlPort uint32) (net.Conn, error) {
+	var lastErr error
+
+	for attempt := 0; attempt <= dialRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, lastErr
+			case <-time.After(dialRetryDelay):
+			}
+		}
+
+		conn, err := vsockclient.Dial(ctx, udsPath, controlPort)
+		if err == nil {
+			return conn, nil
+		}
+
+		lastErr = err
+	}
+
+	return nil, lastErr
 }
 
 // SetIdleTimeout overrides the idle deadline Next() applies to each read

--- a/infrastructure/vsockexec/client_test.go
+++ b/infrastructure/vsockexec/client_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -416,5 +417,122 @@ func TestSession_SendStdinAndCloseStdin(t *testing.T) {
 	}
 	if event.Type != vsockexec.EventExit || event.ExitCode != 0 {
 		t.Fatalf("unexpected final event: %+v", event)
+	}
+}
+
+// TestSession_Start_RetriesTransientHandshakeFailure reproduces
+// https://github.com/liquidmetal-dev/flintlock/issues/1205: a CONNECT
+// handshake that occasionally gets EOF instead of the OK reply, well below
+// the guest-agent protocol layer. Start() must retry the dial instead of
+// failing the whole exec RPC on what's usually a one-off blip.
+func TestSession_Start_RetriesTransientHandshakeFailure(t *testing.T) {
+	const port = 1024
+	const failuresBeforeSuccess = 2
+
+	var attempts int32
+
+	dir := t.TempDir()
+	udsPath := filepath.Join(dir, "vm.vsock")
+
+	l, err := net.Listen("unix", udsPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { l.Close() })
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+
+			if atomic.AddInt32(&attempts, 1) <= failuresBeforeSuccess {
+				// Simulate the reported failure: close before any handshake
+				// reply, so the client's read gets EOF.
+				conn.Close()
+
+				continue
+			}
+
+			go func(conn net.Conn) {
+				defer conn.Close()
+
+				r := bufio.NewReader(conn)
+				line, err := r.ReadString('\n')
+				if err != nil || strings.TrimSpace(line) != fmt.Sprintf("CONNECT %d", port) {
+					return
+				}
+				fmt.Fprintf(conn, "OK 0\n")
+
+				if _, err := vsockclient.ReadFrame(conn); err != nil {
+					return
+				}
+				vsockclient.WriteExit(conn, 0)
+			}(conn)
+		}
+	}()
+
+	restore := vsockexec.SetDialRetryParams(failuresBeforeSuccess+1, 10*time.Millisecond)
+	defer restore()
+
+	session, err := vsockexec.Start(context.Background(), udsPath, port, &vsockclient.Exec{Cmd: "true"})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer session.Close()
+
+	event, err := session.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if event.Type != vsockexec.EventExit || event.ExitCode != 0 {
+		t.Fatalf("unexpected final event: %+v", event)
+	}
+
+	if got := atomic.LoadInt32(&attempts); got != failuresBeforeSuccess+1 {
+		t.Fatalf("dial attempts = %d, want %d", got, failuresBeforeSuccess+1)
+	}
+}
+
+// TestSession_Start_GivesUpAfterRetriesExhausted confirms Start() surfaces
+// an error once the handshake keeps failing past the configured retry
+// count, rather than retrying forever.
+func TestSession_Start_GivesUpAfterRetriesExhausted(t *testing.T) {
+	const port = 1024
+	const retries = 2
+
+	var attempts int32
+
+	dir := t.TempDir()
+	udsPath := filepath.Join(dir, "vm.vsock")
+
+	l, err := net.Listen("unix", udsPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { l.Close() })
+
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+
+			atomic.AddInt32(&attempts, 1)
+			conn.Close()
+		}
+	}()
+
+	restore := vsockexec.SetDialRetryParams(retries, 5*time.Millisecond)
+	defer restore()
+
+	if _, err := vsockexec.Start(context.Background(), udsPath, port, &vsockclient.Exec{Cmd: "true"}); err == nil {
+		t.Fatal("Start: expected error, got nil")
+	}
+
+	if got, want := atomic.LoadInt32(&attempts), int32(retries+1); got != want {
+		t.Fatalf("dial attempts = %d, want %d", got, want)
 	}
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -128,4 +128,23 @@ const (
 	// TimeoutSec-derived deadline (ExecSessionIdleGrace /
 	// ExecSessionUnboundedIdleCeiling above) for the life of the session.
 	ExecSessionIdleTimeout time.Duration = 15 * time.Second
+
+	// GuestAgentDialRetries is how many extra attempts a guest-agent
+	// control-channel dial (the Firecracker/Cloud Hypervisor vsock-UDS
+	// CONNECT handshake) gets after an initial failure, before giving up.
+	// Rapid repeated dials against the same vsock port (e.g. a caller
+	// polling readiness with a no-op exec) have been observed to
+	// occasionally get EOF instead of the handshake's OK reply, well
+	// below the guest-agent protocol layer — most likely a transient
+	// vsock multiplexer hiccup rather than a real failure to connect. A
+	// few quick retries let the handshake ride that out instead of
+	// failing the whole exec RPC on what's usually a one-off blip.
+	GuestAgentDialRetries = 3
+
+	// GuestAgentDialRetryDelay is the delay between guest-agent
+	// control-channel dial attempts; see GuestAgentDialRetries. Kept
+	// short and fixed: this only needs to survive a brief transient
+	// hiccup within a single RPC's lifetime, not implement a general
+	// backoff policy.
+	GuestAgentDialRetryDelay time.Duration = 200 * time.Millisecond
 )


### PR DESCRIPTION
## Summary

Fixes #1205.

Firecracker/Cloud Hypervisor's vsock-UDS CONNECT handshake has been observed
to occasionally return EOF instead of an OK reply when dialled rapidly and
repeatedly against the same guest CID/port (e.g. `flintlockclient.WaitReady`
polling readiness with a no-op `exec true` roughly once a second) — well
below the guest-agent protocol layer, before any exec exchange even starts.

`flintlockd` opens a brand-new vsock dial+handshake for every single exec
RPC (`infrastructure/grpc/exec_server.go` → `vsockexec.Start`), with no
retry: a single failed handshake was returned straight up as a fatal error
for the whole RPC. That's very likely surfacing an underlying
Firecracker/Cloud Hypervisor vsock multiplexer hiccup under rapid
connect/disconnect churn (outside this repo's control), but flintlock had
no cushion for it.

- Retry the dial+handshake step in `vsockexec.Start` up to
  `defaults.GuestAgentDialRetries` (3) extra times, with
  `defaults.GuestAgentDialRetryDelay` (200ms) between attempts, before
  giving up.
- Scoped strictly to the connect step, before any exec request is sent —
  a failure once a connection is established is a different, unrelated
  failure mode and isn't retried here.
- `#1201`/`#1204` already harden the post-handshake idle-read path against
  vsock transport flakiness; this covers the CONNECT handshake itself,
  which neither of those touched.

## Test plan

- [x] `infrastructure/vsockexec` unit tests, including two new cases:
      `TestSession_Start_RetriesTransientHandshakeFailure` (reproduces the
      reported EOF-on-first-attempt, succeeds on retry) and
      `TestSession_Start_GivesUpAfterRetriesExhausted` (confirms retries
      are still bounded).
- [x] `make test`
- [x] `make lint`